### PR TITLE
refactor: appnavbar 확장성 개선

### DIFF
--- a/src/app/_shared/components/AppNavbar.tsx
+++ b/src/app/_shared/components/AppNavbar.tsx
@@ -14,35 +14,22 @@ import {
 
 import { useAppNavigation } from "@/app/_shared/hooks/useAppNavigation";
 
-const navItems = [
-  {
-    id: "home",
-    label: "쇼핑 홈",
-    href: "/",
-  },
-  {
-    id: "deal",
-    label: "특가",
-    href: "/?tab=deal",
-  },
-];
-
 function AppNavbar() {
-  const { currentPage } = useAppNavigation();
+  const { currentPage, mainNavItems } = useAppNavigation();
   const router = useRouter();
 
-  const handleTabClick = (page: string, event: React.MouseEvent) => {
+  const handleTabClick = (pageId: string, event: React.MouseEvent) => {
     event.preventDefault();
-    if (currentPage === page) return;
+    if (currentPage === pageId) return;
     else {
-      router.push(navItems.find((item) => item.id === page)?.href || "/");
+      router.push(mainNavItems.find((item) => item.id === pageId)?.href || "/");
     }
   };
 
   return (
     <nav className={NAV_CONTAINER}>
       <div className={cn(FLEX_ITEMS_CENTER, "px-4")}>
-        {navItems.map((item) => (
+        {mainNavItems.map((item) => (
           <Link
             key={item.id}
             href={item.href}

--- a/src/app/_shared/components/AppSwipeNavbar.tsx
+++ b/src/app/_shared/components/AppSwipeNavbar.tsx
@@ -15,22 +15,30 @@ interface SwipeContainerProps {
 const SWIPE_THRESHOLD = 50;
 
 function AppSwipeNavbar({ children }: SwipeContainerProps) {
-  const { currentPage } = useAppNavigation();
+  const { currentPage, mainNavItems } = useAppNavigation();
   const router = useRouter();
 
   const handleDragEnd = (
     event: MouseEvent | TouchEvent | PointerEvent,
-    info: PanInfo,
+    info: PanInfo
   ) => {
     const { offset } = info;
 
+    const currentPageIndex = mainNavItems.findIndex(
+      (item) => item.id === currentPage
+    );
+
+    if (currentPageIndex === -1) return;
+
     if (offset.x > SWIPE_THRESHOLD) {
-      if (currentPage === "deal") {
-        router.push("/");
+      if (currentPageIndex > 0) {
+        const previousPage = mainNavItems[currentPageIndex - 1];
+        router.push(previousPage.href);
       }
     } else if (offset.x < -SWIPE_THRESHOLD) {
-      if (currentPage === "home") {
-        router.push("/?tab=deal");
+      if (currentPageIndex < mainNavItems.length - 1) {
+        const nextPage = mainNavItems[currentPageIndex + 1];
+        router.push(nextPage.href);
       }
     }
   };

--- a/src/app/_shared/hooks/useAppNavigation.tsx
+++ b/src/app/_shared/hooks/useAppNavigation.tsx
@@ -1,28 +1,26 @@
 import { useCallback } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-
-type NavigationPage = "home" | "product" | "cart" | "deal";
+import { NAV_ITEMS, NavigationPage } from "@/lib/constants/navigation";
 
 function useAppNavigation() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const currentPage = ((): NavigationPage => {
-    if (pathname === "/cart") return "cart";
-    if (pathname.startsWith("/product/")) return "product";
-    if (pathname === "/") {
-      const tab = searchParams.get("tab");
-      const view = searchParams.get("view");
-      if (tab === "deal" || view === "brand" || view === "daily") {
-        return "deal";
+  const currentPage: NavigationPage = ((): NavigationPage => {
+    for (const item of NAV_ITEMS) {
+      if (item.match(pathname, searchParams)) {
+        return item.id;
       }
-      return "home";
     }
     return "home";
   })();
 
-  const isMainPage = currentPage === "home" || currentPage === "deal";
+  const isMainPage = NAV_ITEMS.some(
+    (item) => item.id === currentPage && item.isMain
+  );
+
+  const mainNavItems = NAV_ITEMS.filter((item) => item.isMain);
 
   const goBack = useCallback(() => {
     router.back();
@@ -31,6 +29,7 @@ function useAppNavigation() {
   return {
     currentPage,
     isMainPage,
+    mainNavItems,
     goBack,
   };
 }

--- a/src/app/_shared/hooks/useAppNavigation.tsx
+++ b/src/app/_shared/hooks/useAppNavigation.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
 import { NAV_ITEMS, NavigationPage } from "@/lib/constants/navigation";
 
 function useAppNavigation() {

--- a/src/lib/constants/navigation.ts
+++ b/src/lib/constants/navigation.ts
@@ -1,0 +1,45 @@
+type NavItem = {
+  id: NavigationPage;
+  label: string;
+  href: string;
+  isMain: boolean;
+  match: (pathname: string, searchParams: URLSearchParams) => boolean;
+};
+
+export type NavigationPage = "home" | "product" | "cart" | "deal";
+
+export const NAV_ITEMS: NavItem[] = [
+  {
+    id: "home",
+    label: "쇼핑 홈",
+    href: "/",
+    isMain: true,
+    match: (pathname, searchParams) =>
+      pathname === "/" && !searchParams.get("tab") && !searchParams.get("view"),
+  },
+  {
+    id: "deal",
+    label: "특가",
+    href: "/?tab=deal",
+    isMain: true,
+    match: (pathname, searchParams) =>
+      pathname === "/" &&
+      (searchParams.get("tab") === "deal" ||
+        searchParams.get("view") === "brand" ||
+        searchParams.get("view") === "daily"),
+  },
+  {
+    id: "cart",
+    label: "장바구니",
+    href: "/cart",
+    isMain: false,
+    match: (pathname) => pathname === "/cart",
+  },
+  {
+    id: "product",
+    label: "상품 상세",
+    href: "/product",
+    isMain: false,
+    match: (pathname) => pathname.startsWith("/product/"),
+  },
+];


### PR DESCRIPTION
## #️⃣연관된 이슈

- #37 

## 📝작업 내용

1. 기존에 root 페이지에서 navitems를 추가하려면 appnavbar, appswipenabvar 등을 수정해야 돼서 응집도가 낮았음
2. constant/navigation에서 navitems만 추가하면 자동으로 메인 페이지에 탭이 추가됨
3. 각 페이지에 따른 navitem은 각 컴포넌트에서 관리
