### PR TITLE
refactor: use cart store 리팩토링

### DIFF
--- a/src/app/cart/stores/useCartStore.tsx
+++ b/src/app/cart/stores/useCartStore.tsx
@@ -9,6 +9,14 @@ import {
 import { CartItem, CartStore } from "@/lib/types/cartType";
 import { Product, ProductOption } from "@/lib/types/productType";
 
+const ERROR_MESSAGE = {
+  QUANTITY_MINIMUM: `수량은 1개 이상이어야 합니다.`,
+  MISSING_OPTIONS: `상품 옵션 정보가 누락되어 장바구니에 추가할 수 없습니다.`,
+  QUANTITY_MAXIMUM: (max: number) => `최대 구매 가능 수량은 ${max}개입니다.`,
+  QUANTITY_EXCEEDED: (current: number, remaining: number) =>
+    `이미 장바구니에 ${current}개가 담겨있습니다. 최대 ${remaining}개까지 추가 가능합니다.`,
+} as const;
+
 const useCartStore = create<CartStore>()(
   persist(
     (set, get) => ({
@@ -21,7 +29,7 @@ const useCartStore = create<CartStore>()(
         selectedOptions: ProductOption[],
         quantity: number,
         discountedPrice?: number,
-        allAvailableOptions?: ProductOption[],
+        allAvailableOptions?: ProductOption[]
       ) => {
         const { items } = get();
 
@@ -31,7 +39,7 @@ const useCartStore = create<CartStore>()(
 
         if (!allAvailableOptions || allAvailableOptions.length === 0) {
           throw new Error(
-            `상품 옵션 정보가 누락되어 장바구니에 추가할 수 없습니다.`,
+            `상품 옵션 정보가 누락되어 장바구니에 추가할 수 없습니다.`
           );
         }
 
@@ -39,7 +47,7 @@ const useCartStore = create<CartStore>()(
           createOptionsFromSelection(selectedOptions);
         const maxPurchaseQuantity = getMaxPurchaseQuantity(
           allAvailableOptions,
-          selectedOptionConfig,
+          selectedOptionConfig
         );
 
         const existingItemIndex = items.findIndex((item) => {
@@ -60,14 +68,14 @@ const useCartStore = create<CartStore>()(
               maxPurchaseQuantity - existingItem.quantity;
             throw new Error(
               `이미 장바구니에 ${existingItem.quantity}개가 담겨있습니다. 
-              최대 ${remainingQuantity}개까지 추가 가능합니다.`,
+              최대 ${remainingQuantity}개까지 추가 가능합니다.`
             );
           }
 
           const itemPrice = discountedPrice || product.basePrice;
           const optionPrice = selectedOptions.reduce(
             (sum, option) => sum + option.additionalPrice,
-            0,
+            0
           );
           const totalItemPrice = (itemPrice + optionPrice) * newQuantity;
 
@@ -83,20 +91,20 @@ const useCartStore = create<CartStore>()(
             totalItems: state.totalItems + quantity,
             totalPrice: updatedItems.reduce(
               (sum, item) => sum + item.totalPrice,
-              0,
+              0
             ),
           }));
         } else {
           if (quantity > maxPurchaseQuantity) {
             throw new Error(
-              `최대 구매 가능 수량은 ${maxPurchaseQuantity}개입니다.`,
+              `최대 구매 가능 수량은 ${maxPurchaseQuantity}개입니다.`
             );
           }
 
           const itemPrice = discountedPrice || product.basePrice;
           const optionPrice = selectedOptions.reduce(
             (sum, option) => sum + option.additionalPrice,
-            0,
+            0
           );
           const totalItemPrice = (itemPrice + optionPrice) * quantity;
 
@@ -131,7 +139,7 @@ const useCartStore = create<CartStore>()(
             totalItems: state.totalItems - itemToRemove.quantity,
             totalPrice: updatedItems.reduce(
               (sum, item) => sum + item.totalPrice,
-              0,
+              0
             ),
           }));
         }
@@ -140,7 +148,7 @@ const useCartStore = create<CartStore>()(
       updateQuantity: (
         itemId: string,
         quantity: number,
-        allAvailableOptions?: ProductOption[],
+        allAvailableOptions?: ProductOption[]
       ) => {
         const { items } = get();
         const itemIndex = items.findIndex((item) => item.id === itemId);
@@ -153,11 +161,11 @@ const useCartStore = create<CartStore>()(
           }
 
           const optionsConfig = createOptionsFromSelection(
-            existingItem.selectedOptions,
+            existingItem.selectedOptions
           );
           const maxQuantity = getMaxPurchaseQuantity(
             allAvailableOptions || [],
-            optionsConfig,
+            optionsConfig
           );
           if (quantity > maxQuantity) {
             throw new Error(`최대 구매 가능 수량은 ${maxQuantity}개입니다.`);
@@ -168,7 +176,7 @@ const useCartStore = create<CartStore>()(
             existingItem.discountPrice || existingItem.product.basePrice;
           const optionPrice = existingItem.selectedOptions.reduce(
             (sum, option) => sum + option.additionalPrice,
-            0,
+            0
           );
           const totalItemPrice = (itemPrice + optionPrice) * quantity;
 
@@ -182,11 +190,11 @@ const useCartStore = create<CartStore>()(
             items: updatedItems,
             totalItems: updatedItems.reduce(
               (sum, item) => sum + item.quantity,
-              0,
+              0
             ),
             totalPrice: updatedItems.reduce(
               (sum, item) => sum + item.totalPrice,
-              0,
+              0
             ),
           }));
         }
@@ -204,8 +212,8 @@ const useCartStore = create<CartStore>()(
         totalItems: state.totalItems,
         totalPrice: state.totalPrice,
       }),
-    },
-  ),
+    }
+  )
 );
 
 export default useCartStore;

--- a/src/app/cart/stores/useCartStore.tsx
+++ b/src/app/cart/stores/useCartStore.tsx
@@ -31,6 +31,19 @@ const calculateItemPrice = (
   return (itemPrice + optionPrice) * quantity;
 };
 
+const findExistingItemIndex = (
+  items: CartItem[],
+  productId: string,
+  selectedOptions: ProductOption[]
+): number => {
+  return items.findIndex((item) => {
+    return (
+      item.product.id === productId &&
+      JSON.stringify(item.selectedOptions) === JSON.stringify(selectedOptions)
+    );
+  });
+};
+
 const useCartStore = create<CartStore>()(
   persist(
     (set, get) => ({

--- a/src/app/cart/stores/useCartStore.tsx
+++ b/src/app/cart/stores/useCartStore.tsx
@@ -139,6 +139,9 @@ const useCartStore = create<CartStore>()(
 
       removeFromCart: (itemId: string) => {
         const { items } = get();
+        const itemIndex = items.findIndex((item) => item.id === itemId);
+        if (itemIndex === -1) return;
+
         const updatedItems = items.filter((item) => item.id !== itemId);
 
         const totalItems = updatedItems.reduce(

--- a/src/app/cart/stores/useCartStore.tsx
+++ b/src/app/cart/stores/useCartStore.tsx
@@ -3,9 +3,9 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 import {
+  calculateItemPrice,
   createOptionsFromSelection,
   getMaxPurchaseQuantity,
-  calculateItemPrice,
 } from "@/lib/utils/productOptionUtils";
 import { CartItem, CartStore } from "@/lib/types/cartType";
 import { Product, ProductOption } from "@/lib/types/productType";

--- a/src/app/cart/stores/useCartStore.tsx
+++ b/src/app/cart/stores/useCartStore.tsx
@@ -5,6 +5,7 @@ import { persist } from "zustand/middleware";
 import {
   createOptionsFromSelection,
   getMaxPurchaseQuantity,
+  calculateItemPrice,
 } from "@/lib/utils/productOptionUtils";
 import { CartItem, CartStore } from "@/lib/types/cartType";
 import { Product, ProductOption } from "@/lib/types/productType";
@@ -17,20 +18,6 @@ const ERROR_MESSAGE = {
     `이미 장바구니에 ${current}개가 담겨있습니다. 
   최대 ${remaining}개까지 추가 가능합니다.`,
 } as const;
-
-const calculateItemPrice = (
-  basePrice: number,
-  selectedOptions: ProductOption[],
-  quantity: number,
-  discountedPrice?: number
-) => {
-  const itemPrice = discountedPrice || basePrice;
-  const optionPrice = selectedOptions.reduce(
-    (sum, option) => sum + option.additionalPrice,
-    0
-  );
-  return (itemPrice + optionPrice) * quantity;
-};
 
 const findExistingItemIndex = (
   items: CartItem[],

--- a/src/app/cart/stores/useCartStore.tsx
+++ b/src/app/cart/stores/useCartStore.tsx
@@ -17,6 +17,20 @@ const ERROR_MESSAGE = {
     `이미 장바구니에 ${current}개가 담겨있습니다. 최대 ${remaining}개까지 추가 가능합니다.`,
 } as const;
 
+const calculateItemPrice = (
+  basePrice: number,
+  selectedOptions: ProductOption[],
+  quantity: number,
+  discountedPrice?: number
+) => {
+  const itemPrice = discountedPrice || basePrice;
+  const optionPrice = selectedOptions.reduce(
+    (sum, option) => sum + option.additionalPrice,
+    0
+  );
+  return (itemPrice + optionPrice) * quantity;
+};
+
 const useCartStore = create<CartStore>()(
   persist(
     (set, get) => ({

--- a/src/app/cart/stores/useCartStore.tsx
+++ b/src/app/cart/stores/useCartStore.tsx
@@ -25,13 +25,13 @@ const findExistingItemIndex = (
   selectedOptions: ProductOption[]
 ): number => {
   return items.findIndex((item) => {
-    return (
-      item.product.id === productId &&
-      JSON.stringify(item.selectedOptions) === JSON.stringify(selectedOptions)
+    if (item.product.id !== productId) return false;
+    if (item.selectedOptions.length !== selectedOptions.length) return false;
+    return item.selectedOptions.every((option) =>
+      selectedOptions.some((opt) => opt.id === option.id)
     );
   });
 };
-
 const useCartStore = create<CartStore>()(
   persist(
     (set, get) => ({

--- a/src/app/product/[id]/components/AddToCartForm.tsx
+++ b/src/app/product/[id]/components/AddToCartForm.tsx
@@ -93,14 +93,14 @@ function AddToCartForm({ productDetail, onSuccess }: AddToCartFormProps) {
           <div className="flex gap-2">
             <Button
               type="submit"
-              className="flex-1"
+              className="flex-1 h-12 text-lg font-bold"
               disabled={!addToCartForm.allOptionsSelected}
             >
               장바구니
             </Button>
             <Button
               type="button"
-              className="flex-1 bg-blue-500 hover:bg-blue-600"
+              className="flex-1 h-12 text-lg font-bold bg-blue-500 hover:bg-blue-600"
               disabled={
                 !addToCartForm.allOptionsSelected ||
                 updateStockMutation.isPending

--- a/src/app/product/[id]/hooks/forms/useAddToCartForm.tsx
+++ b/src/app/product/[id]/hooks/forms/useAddToCartForm.tsx
@@ -6,6 +6,7 @@ import * as z from "zod";
 
 import {
   areAllOptionsSelected,
+  calculateItemPrice,
   extractOptionKeys,
   findMatchingOption,
   getMaxPurchaseQuantity,
@@ -53,12 +54,14 @@ function useAddToCartForm({ productDetail, onSuccess }: UseAddToCartFormProps) {
     watchedOptions,
   );
 
-  const totalAmount = (() => {
-    if (!currentMatchingOption) return 0;
-    const basePrice = discount?.discountedPrice || product.basePrice;
-    const optionPrice = currentMatchingOption.additionalPrice;
-    return (basePrice + optionPrice) * watchedQuantity;
-  })();
+  const totalAmount = currentMatchingOption
+    ? calculateItemPrice(
+        product.basePrice,
+        [currentMatchingOption],
+        watchedQuantity,
+        discount?.discountedPrice
+      )
+    : 0;
 
   const handleOptionSelectionChange = (newOptions: Record<string, string>) => {
     form.setValue("options", newOptions);

--- a/src/lib/utils/productOptionUtils.ts
+++ b/src/lib/utils/productOptionUtils.ts
@@ -129,6 +129,20 @@ function toProductPreview(
   };
 }
 
+const calculateItemPrice = (
+  basePrice: number,
+  selectedOptions: ProductOption[],
+  quantity: number,
+  discountedPrice?: number
+) => {
+  const itemPrice = discountedPrice || basePrice;
+  const optionPrice = selectedOptions.reduce(
+    (sum, option) => sum + option.additionalPrice,
+    0
+  );
+  return (itemPrice + optionPrice) * quantity;
+};
+
 export {
   areAllOptionsSelected,
   convertRecordToKeyValueArray,
@@ -138,4 +152,5 @@ export {
   getMaxPurchaseQuantity,
   safelyParseOptionValue,
   toProductPreview,
+  calculateItemPrice,
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

- #45 

## 📝작업 내용

- caluate item price는 lib/utils의 product option utils에서 관리
- 에러메시지 상수로 분리
- 장바구니 id와 상품의 옵션 id를 비교하는 유틸은 내부에서 추상화
