### PR TITLE
feat: add to cart options 드롭다운 활성화

### DIFF
--- a/src/app/product/[id]/components/AddToCartOptions.tsx
+++ b/src/app/product/[id]/components/AddToCartOptions.tsx
@@ -30,8 +30,14 @@ function AddToCartOptions({
   control,
   onSelectionChange,
 }: AddToCartOptionsProps) {
-  const { separatedOptions, optionKeys, watchedOptions, handleOptionChange } =
-    useProductOptions(productOptions, control);
+  const {
+    separatedOptions,
+    optionKeys,
+    watchedOptions,
+    openDropdowns,
+    handleOptionChange,
+    handleDropdownToggle,
+  } = useProductOptions(productOptions, control);
 
   return (
     <div className="space-y-4">
@@ -52,6 +58,8 @@ function AddToCartOptions({
                 <FormLabel>{key}</FormLabel>
                 <Select
                   value={field.value || ""}
+                  open={openDropdowns[key] || false}
+                  onOpenChange={(isOpen) => handleDropdownToggle(key, isOpen)}
                   onValueChange={(value) =>
                     handleOptionChange(key, value, onSelectionChange)
                   }

--- a/src/app/product/[id]/hooks/forms/useProductOptions.tsx
+++ b/src/app/product/[id]/hooks/forms/useProductOptions.tsx
@@ -1,5 +1,5 @@
+import { useEffect, useRef, useState, useMemo } from "react";
 import { Control, useWatch } from "react-hook-form";
-import { useState, useEffect, useRef } from "react";
 
 import {
   extractOptionKeys,
@@ -18,22 +18,28 @@ function useProductOptions(
   );
   const isInitialized = useRef(false);
 
-  const separated: Record<string, { value: string; option: ProductOption }[]> =
-    {};
+  const separatedOptions = useMemo(() => {
+    const separated: Record<
+      string,
+      { value: string; option: ProductOption }[]
+    > = {};
 
-  productOptions?.forEach((option) => {
-    const parsed = safelyParseOptionValue(option);
+    productOptions?.forEach((option) => {
+      const parsed = safelyParseOptionValue(option);
 
-    Object.entries(parsed).forEach(([key, value]) => {
-      if (!separated[key]) {
-        separated[key] = [];
-      }
+      Object.entries(parsed).forEach(([key, value]) => {
+        if (!separated[key]) {
+          separated[key] = [];
+        }
 
-      if (!separated[key].some((item) => item.value === value)) {
-        separated[key].push({ value, option });
-      }
+        if (!separated[key].some((item) => item.value === value)) {
+          separated[key].push({ value, option });
+        }
+      });
     });
-  });
+
+    return separated;
+  }, [productOptions]);
 
   useEffect(() => {
     if (optionKeys.length > 0 && !isInitialized.current) {
@@ -43,7 +49,7 @@ function useProductOptions(
         [optionKeys[0]]: true,
       }));
     }
-  }, [optionKeys.length]);
+  }, [optionKeys]);
 
   const handleOptionChange = (
     key: string,
@@ -86,7 +92,7 @@ function useProductOptions(
 
   return {
     watchedOptions,
-    separatedOptions: separated,
+    separatedOptions,
     optionKeys,
     openDropdowns,
     handleOptionChange,

--- a/src/app/product/[id]/hooks/forms/useProductOptions.tsx
+++ b/src/app/product/[id]/hooks/forms/useProductOptions.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo,useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Control, useWatch } from "react-hook-form";
 
 import {
@@ -11,12 +11,14 @@ function useProductOptions(
   productOptions: ProductOption[],
   control: Control<{ options: Record<string, string>; quantity: number }>
 ) {
-  const optionKeys = extractOptionKeys(productOptions);
+  const optionKeys = useMemo(
+    () => extractOptionKeys(productOptions),
+    [productOptions]
+  );
   const watchedOptions = useWatch({ control, name: "options" });
   const [openDropdowns, setOpenDropdowns] = useState<Record<string, boolean>>(
     {}
   );
-  const isInitialized = useRef(false);
 
   const separatedOptions = useMemo(() => {
     const separated: Record<
@@ -42,12 +44,10 @@ function useProductOptions(
   }, [productOptions]);
 
   useEffect(() => {
-    if (optionKeys.length > 0 && !isInitialized.current) {
-      isInitialized.current = true;
-      setOpenDropdowns((prev) => ({
-        ...prev,
-        [optionKeys[0]]: true,
-      }));
+    if (optionKeys.length > 0) {
+      setOpenDropdowns({ [optionKeys[0]]: true });
+    } else {
+      setOpenDropdowns({});
     }
   }, [optionKeys]);
 

--- a/src/app/product/[id]/hooks/forms/useProductOptions.tsx
+++ b/src/app/product/[id]/hooks/forms/useProductOptions.tsx
@@ -1,4 +1,5 @@
 import { Control, useWatch } from "react-hook-form";
+import { useState, useEffect, useRef } from "react";
 
 import {
   extractOptionKeys,
@@ -12,6 +13,11 @@ function useProductOptions(
 ) {
   const optionKeys = extractOptionKeys(productOptions);
   const watchedOptions = useWatch({ control, name: "options" });
+  const [openDropdowns, setOpenDropdowns] = useState<Record<string, boolean>>(
+    {}
+  );
+  const isInitialized = useRef(false);
+
   const separated: Record<string, { value: string; option: ProductOption }[]> =
     {};
 
@@ -29,6 +35,16 @@ function useProductOptions(
     });
   });
 
+  useEffect(() => {
+    if (optionKeys.length > 0 && !isInitialized.current) {
+      isInitialized.current = true;
+      setOpenDropdowns((prev) => ({
+        ...prev,
+        [optionKeys[0]]: true,
+      }));
+    }
+  }, [optionKeys.length]);
+
   const handleOptionChange = (
     key: string,
     value: string,
@@ -36,13 +52,45 @@ function useProductOptions(
   ) => {
     const newOptions = { ...watchedOptions, [key]: value };
     onChange(newOptions);
+
+    const currentIndex = optionKeys.indexOf(key);
+    const nextKey = optionKeys[currentIndex + 1];
+
+    setOpenDropdowns((prev) => {
+      const newState = { ...prev };
+
+      newState[key] = false;
+
+      if (nextKey) {
+        const allPreviousSelected = optionKeys
+          .slice(0, currentIndex + 1)
+          .every(
+            (prevKey) => newOptions[prevKey] && newOptions[prevKey] !== ""
+          );
+
+        if (allPreviousSelected) {
+          newState[nextKey] = true;
+        }
+      }
+
+      return newState;
+    });
+  };
+
+  const handleDropdownToggle = (key: string, isOpen: boolean) => {
+    setOpenDropdowns((prev) => ({
+      ...prev,
+      [key]: isOpen,
+    }));
   };
 
   return {
     watchedOptions,
     separatedOptions: separated,
     optionKeys,
+    openDropdowns,
     handleOptionChange,
+    handleDropdownToggle,
   };
 }
 

--- a/src/app/product/[id]/hooks/forms/useProductOptions.tsx
+++ b/src/app/product/[id]/hooks/forms/useProductOptions.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useMemo } from "react";
+import { useEffect, useMemo,useRef, useState } from "react";
 import { Control, useWatch } from "react-hook-form";
 
 import {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #34 

## 📝작업 내용

- 옵션 드롭다운 자동 열림 hook 추가 (openDropdowns)
- seperate options에 use memo 적용
    - product opitons가 변경 될 때만 리렌더링 되도록