### PR TITLE
feat: product detail의 스크롤 상태를 추적하는 observer hook 추가

### DIFF
--- a/src/app/product/[id]/components/ProductDescription.tsx
+++ b/src/app/product/[id]/components/ProductDescription.tsx
@@ -8,11 +8,11 @@ function ProductDescription({
   return (
     <div className="bg-white">
       <div className="space-y-4">
-        {descriptionImages.map((imageUrl, index) => (
-          <div key={index} className="w-full h-auto">
+        {descriptionImages.map((imageUrl) => (
+          <div key={imageUrl} className="w-full h-auto">
             <Image
               src={imageUrl}
-              alt={`제품 상세 이미지 ${index + 1}`}
+              alt={`제품 상세 이미지`}
               width={468}
               height={0}
             />

--- a/src/app/product/[id]/components/ProductDescription.tsx
+++ b/src/app/product/[id]/components/ProductDescription.tsx
@@ -1,6 +1,10 @@
 import Image from "next/image";
 
-function ProductDescription({ descriptionImages }: { descriptionImages: string[] }) {
+function ProductDescription({
+  descriptionImages,
+}: {
+  descriptionImages: string[];
+}) {
   return (
     <div className="bg-white">
       <div className="space-y-4">

--- a/src/app/product/[id]/components/ProductDescription.tsx
+++ b/src/app/product/[id]/components/ProductDescription.tsx
@@ -1,10 +1,10 @@
 import Image from "next/image";
 
-function ProductDescription({ detailImages }: { detailImages: string[] }) {
+function ProductDescription({ descriptionImages }: { descriptionImages: string[] }) {
   return (
     <div className="bg-white">
       <div className="space-y-4">
-        {detailImages.map((imageUrl, index) => (
+        {descriptionImages.map((imageUrl, index) => (
           <div key={index} className="w-full h-auto">
             <Image
               src={imageUrl}

--- a/src/app/product/[id]/components/ProductDetailView.tsx
+++ b/src/app/product/[id]/components/ProductDetailView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 
 import { ProductDetailInfo } from "@/lib/types/productType";
@@ -23,6 +23,7 @@ import ProductDescription from "@/app/product/[id]/components/ProductDescription
 import ProductOverview from "@/app/product/[id]/components/ProductOverview";
 import ProductReview from "@/app/product/[id]/components/ProductReview";
 import ProductTab from "@/app/product/[id]/components/ProductTab";
+import useProductTabObserver from "@/app/product/[id]/hooks/useProductTabObserver";
 
 type ProductDetailProps = {
   productDetail: ProductDetailInfo;
@@ -31,7 +32,12 @@ type ProductDetailProps = {
 
 function ProductDetailView({ productDetail }: ProductDetailProps) {
   const { activeTab, setActiveTab, isVisible } = useProductTab();
+  const reviewRef = useRef<HTMLDivElement | null>(null);
+  const descriptionRef = useRef<HTMLDivElement | null>(null);
+
   const [isSheetOpen, setIsSheetOpen] = useState(false);
+
+  useProductTabObserver({ reviewRef, descriptionRef, setActiveTab });
 
   return (
     <div className="h-full flex flex-col">
@@ -40,17 +46,24 @@ function ProductDetailView({ productDetail }: ProductDetailProps) {
         <div className="bg-gray-100 pt-2">
           <ProductTab
             activeTab={activeTab}
-            onTabChange={setActiveTab}
+            onTabChange={(tab) => {
+              setActiveTab(tab);
+              if (tab === "reviews") {
+                reviewRef.current?.scrollIntoView({ behavior: "smooth" });
+              } else if (tab === "details") {
+                descriptionRef.current?.scrollIntoView({ behavior: "smooth" });
+              }
+            }}
             isVisible={isVisible}
           />
-          {activeTab === "reviews" && (
+          <div ref={reviewRef}>
             <ProductReview reviews={productDetail.reviews ?? []} />
-          )}
-          {activeTab === "details" && (
+          </div>
+          <div ref={descriptionRef}>
             <ProductDescription
               descriptionImages={productDetail.detailImages}
             />
-          )}
+          </div>
         </div>
       </div>
 

--- a/src/app/product/[id]/components/ProductDetailView.tsx
+++ b/src/app/product/[id]/components/ProductDetailView.tsx
@@ -47,7 +47,9 @@ function ProductDetailView({ productDetail }: ProductDetailProps) {
             <ProductReview reviews={productDetail.reviews ?? []} />
           )}
           {activeTab === "details" && (
-            <ProductDescription descriptionImages={productDetail.detailImages} />
+            <ProductDescription
+              descriptionImages={productDetail.detailImages}
+            />
           )}
         </div>
       </div>
@@ -66,7 +68,7 @@ function ProductDetailView({ productDetail }: ProductDetailProps) {
             >
               구매하기
             </Button>
-            
+
             <SheetContent
               side="bottom"
               className="h-[85vh] max-w-[468px] mx-auto rounded-t-2xl p-0 flex flex-col"

--- a/src/app/product/[id]/components/ProductDetailView.tsx
+++ b/src/app/product/[id]/components/ProductDetailView.tsx
@@ -47,7 +47,7 @@ function ProductDetailView({ productDetail }: ProductDetailProps) {
             <ProductReview reviews={productDetail.reviews ?? []} />
           )}
           {activeTab === "details" && (
-            <ProductDescription detailImages={productDetail.detailImages} />
+            <ProductDescription descriptionImages={productDetail.detailImages} />
           )}
         </div>
       </div>

--- a/src/app/product/[id]/components/ProductDetailView.tsx
+++ b/src/app/product/[id]/components/ProductDetailView.tsx
@@ -17,13 +17,13 @@ import {
 } from "@/ui/sheet";
 
 import useProductTab from "@/app/product/[id]/hooks/useProductTab";
+import useProductTabObserver from "@/app/product/[id]/hooks/useProductTabObserver";
 
 import AddToCartForm from "@/app/product/[id]/components/AddToCartForm";
 import ProductDescription from "@/app/product/[id]/components/ProductDescription";
 import ProductOverview from "@/app/product/[id]/components/ProductOverview";
 import ProductReview from "@/app/product/[id]/components/ProductReview";
 import ProductTab from "@/app/product/[id]/components/ProductTab";
-import useProductTabObserver from "@/app/product/[id]/hooks/useProductTabObserver";
 
 type ProductDetailProps = {
   productDetail: ProductDetailInfo;

--- a/src/app/product/[id]/components/ProductDetailView.tsx
+++ b/src/app/product/[id]/components/ProductDetailView.tsx
@@ -33,18 +33,6 @@ function ProductDetailView({ productDetail }: ProductDetailProps) {
   const { activeTab, setActiveTab, isVisible } = useProductTab();
   const [isSheetOpen, setIsSheetOpen] = useState(false);
 
-  const handleAddToCartSuccess = () => {
-    setIsSheetOpen(false);
-  };
-
-  const renderTabContent = () => {
-    if (activeTab === "reviews") {
-      return <ProductReview reviews={productDetail.reviews ?? []} />;
-    } else if (activeTab === "details") {
-      return <ProductDescription detailImages={productDetail.detailImages} />;
-    }
-  };
-
   return (
     <div className="h-full flex flex-col">
       <div className="flex-1 pb-20">
@@ -55,7 +43,12 @@ function ProductDetailView({ productDetail }: ProductDetailProps) {
             onTabChange={setActiveTab}
             isVisible={isVisible}
           />
-          {renderTabContent()}
+          {activeTab === "reviews" && (
+            <ProductReview reviews={productDetail.reviews ?? []} />
+          )}
+          {activeTab === "details" && (
+            <ProductDescription detailImages={productDetail.detailImages} />
+          )}
         </div>
       </div>
 
@@ -73,6 +66,7 @@ function ProductDetailView({ productDetail }: ProductDetailProps) {
             >
               구매하기
             </Button>
+            
             <SheetContent
               side="bottom"
               className="h-[85vh] max-w-[468px] mx-auto rounded-t-2xl p-0 flex flex-col"
@@ -91,7 +85,7 @@ function ProductDetailView({ productDetail }: ProductDetailProps) {
               <div className="flex-1 overflow-hidden">
                 <AddToCartForm
                   productDetail={productDetail}
-                  onSuccess={handleAddToCartSuccess}
+                  onSuccess={() => setIsSheetOpen(false)}
                 />
               </div>
             </SheetContent>

--- a/src/app/product/[id]/components/ProductReview.tsx
+++ b/src/app/product/[id]/components/ProductReview.tsx
@@ -1,11 +1,12 @@
-import Image from "next/image";
 import { useState } from "react";
+import Image from "next/image";
 
 import { formatDateToKor } from "@/lib/utils";
 import { Review } from "@/lib/types/productType";
 
-import ProductRating from "../../components/ProductRating";
 import { Button } from "@/ui/button";
+
+import ProductRating from "../../components/ProductRating";
 
 type ProductReviewProps = {
   reviews: Review[];

--- a/src/app/product/[id]/components/ProductReview.tsx
+++ b/src/app/product/[id]/components/ProductReview.tsx
@@ -1,48 +1,69 @@
 import Image from "next/image";
+import { useState } from "react";
 
 import { formatDateToKor } from "@/lib/utils";
 import { Review } from "@/lib/types/productType";
 
 import ProductRating from "../../components/ProductRating";
+import { Button } from "@/ui/button";
 
 type ProductReviewProps = {
   reviews: Review[];
 };
 
+const MORE_REVIEW_COUNT = 5;
+
 function ProductReview({ reviews }: ProductReviewProps) {
+  const [showAll, setShowAll] = useState(false);
+  const hasMore = reviews.length > MORE_REVIEW_COUNT;
+  const displayedReviews = showAll ? reviews : reviews.slice(0, MORE_REVIEW_COUNT);
+
   return (
     <div className="bg-white">
       <div className="divide-y divide-gray-200">
-        {reviews.length > 0 ? (
-          reviews.map((review) => (
-            <div key={review.id} className="p-4">
-              <div className="flex items-center justify-between mb-2">
-                <div className="flex items-center">
-                  <ProductRating
-                    averageRating={review.reviewScore}
-                    showCount={false}
-                    size="medium"
-                  />
-                  <span className="ml-2 text-sm text-gray-600">
-                    {formatDateToKor(review.createdAt)}
-                  </span>
+        {displayedReviews.length > 0 ? (
+          <>
+            {displayedReviews.map((review) => (
+              <div key={review.id} className="p-4">
+                <div className="flex items-center justify-between mb-2">
+                  <div className="flex items-center">
+                    <ProductRating
+                      averageRating={review.reviewScore}
+                      showCount={false}
+                      size="medium"
+                    />
+                    <span className="ml-2 text-sm text-gray-600">
+                      {formatDateToKor(review.createdAt)}
+                    </span>
+                  </div>
                 </div>
+                <p className="text-gray-800 mb-3">{review.reviewDetail}</p>
+                {review.imageUrl && (
+                  <div className="w-20 h-20 bg-gray-100 rounded-md overflow-hidden">
+                    <Image
+                      src={review.imageUrl}
+                      alt="리뷰 이미지"
+                      className="w-full h-full object-cover"
+                      width={100}
+                      height={100}
+                      priority
+                    />
+                  </div>
+                )}
               </div>
-              <p className="text-gray-800 mb-3">{review.reviewDetail}</p>
-              {review.imageUrl && (
-                <div className="w-20 h-20 bg-gray-100 rounded-md overflow-hidden">
-                  <Image
-                    src={review.imageUrl}
-                    alt="리뷰 이미지"
-                    className="w-full h-full object-cover"
-                    width={100}
-                    height={100}
-                    priority
-                  />
-                </div>
-              )}
-            </div>
-          ))
+            ))}
+            {hasMore && !showAll && (
+              <div className="p-4 text-center">
+                <Button
+                  variant="outline"
+                  onClick={() => setShowAll(true)}
+                  className="w-full"
+                >
+                  더보기
+                </Button>
+              </div>
+            )}
+          </>
         ) : (
           <div className="p-8 text-center text-gray-500">
             <p>아직 리뷰가 없습니다.</p>

--- a/src/app/product/[id]/hooks/useProductTabObserver.tsx
+++ b/src/app/product/[id]/hooks/useProductTabObserver.tsx
@@ -30,7 +30,7 @@ const useProductTabObserver = ({
       },
       {
         rootMargin: "0px 0px -30% 0px",
-        threshold: [0.3, 0.5, 0.7],
+        threshold: 0.3,
       }
     );
 

--- a/src/app/product/[id]/hooks/useProductTabObserver.tsx
+++ b/src/app/product/[id]/hooks/useProductTabObserver.tsx
@@ -18,15 +18,16 @@ const useProductTabObserver = ({
 
     const observer = new IntersectionObserver(
       (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting && entry.intersectionRatio > 0.3) {
-            if (entry.target === reviewEl) {
-              setActiveTab("reviews");
-            } else if (entry.target === descriptionEl) {
-              setActiveTab("details");
-            }
-          }
-        });
+        const visibleEntries = entries.filter((entry) => entry.isIntersecting);
+        if (visibleEntries.length === 0) return;
+        const mostVisible = visibleEntries.reduce((a, b) =>
+          a.intersectionRatio > b.intersectionRatio ? a : b
+        );
+        if (mostVisible.target === reviewEl) {
+          setActiveTab("reviews");
+        } else if (mostVisible.target === descriptionEl) {
+          setActiveTab("details");
+        }
       },
       {
         rootMargin: "0px 0px -30% 0px",

--- a/src/app/product/[id]/hooks/useProductTabObserver.tsx
+++ b/src/app/product/[id]/hooks/useProductTabObserver.tsx
@@ -1,0 +1,44 @@
+import { useEffect } from "react";
+
+type Props = {
+  reviewRef: React.RefObject<HTMLDivElement | null>;
+  descriptionRef: React.RefObject<HTMLDivElement | null>;
+  setActiveTab: (tab: "reviews" | "details") => void;
+};
+
+const useProductTabObserver = ({
+  reviewRef,
+  descriptionRef,
+  setActiveTab,
+}: Props) => {
+  useEffect(() => {
+    const reviewEl = reviewRef.current;
+    const descriptionEl = descriptionRef.current;
+    if (!reviewEl || !descriptionEl) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting && entry.intersectionRatio > 0.3) {
+            if (entry.target === reviewEl) {
+              setActiveTab("reviews");
+            } else if (entry.target === descriptionEl) {
+              setActiveTab("details");
+            }
+          }
+        });
+      },
+      {
+        rootMargin: "0px 0px -30% 0px",
+        threshold: [0.3, 0.5, 0.7],
+      }
+    );
+
+    observer.observe(reviewEl);
+    observer.observe(descriptionEl);
+
+    return () => observer.disconnect();
+  }, [reviewRef, descriptionRef, setActiveTab]);
+};
+
+export default useProductTabObserver;


### PR DESCRIPTION
## #️⃣연관된 이슈

- #42 

## 📝작업 내용

- product description components 매개변수명 product detail에서 description으로 변경

- 기존
    - product tab을 클릭해야지만 review 또는 description components가 보였음
    - product review 개수 제한 없이 렌더링

- 변경 사항
    - product tab을 클릭하지 않고도 스크롤 시에도 review와 description이 뜨도록 변경
    - observer hook의 경우 30% 이상 해당 컴포넌트가 보이면 탭의 상태가 변경되도록함
    - product review가 5개 이상일 시 더보기 버튼을 누르면 나머지 전체 리뷰가 보이도록 product review에 showAll 상태 추가
