### PR TITLE
fix: product tab observer hook의 threshold값을 0.3에서 0.1로 조정

### DIFF
--- a/src/app/product/[id]/hooks/useProductTabObserver.tsx
+++ b/src/app/product/[id]/hooks/useProductTabObserver.tsx
@@ -32,8 +32,8 @@ const useProductTabObserver = ({
         }
       },
       {
-        rootMargin: "0px 0px -30% 0px",
-        threshold: 0.3,
+        rootMargin: "0px 0px -10% 0px",
+        threshold: 0.1,
       }
     );
 

--- a/src/app/product/[id]/hooks/useProductTabObserver.tsx
+++ b/src/app/product/[id]/hooks/useProductTabObserver.tsx
@@ -8,6 +8,9 @@ interface UseProductTabObserverProps {
   setActiveTab: (tab: ProductTabType) => void;
 }
 
+const ROOT_MARGIN = "0px 0px -10% 0px";
+const INTERSECTION_THRESHOLD = 0.1;
+
 const useProductTabObserver = ({
   reviewRef,
   descriptionRef,
@@ -32,8 +35,8 @@ const useProductTabObserver = ({
         }
       },
       {
-        rootMargin: "0px 0px -10% 0px",
-        threshold: 0.1,
+        rootMargin: ROOT_MARGIN,
+        threshold: INTERSECTION_THRESHOLD,
       }
     );
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #55 

## 📝작업 내용
- 문제 상황
    - 특정 페이지에서 observer hook이 동작하지 않음
- 해결 방법
    - threshold와 root margin top의 값을 0.3에서 0.1로 조정함
    - 상품 상세 이미지의 height값이 제각각이기에 10%만 감지되도 element를 감지하도록함