### PR TITLE
refactor: export 방식 통일, 타입 선언 정리, AddTo 컴포넌트명을 Product로 변경

### DIFF
--- a/src/app/_point/components/PointDisplay.tsx
+++ b/src/app/_point/components/PointDisplay.tsx
@@ -52,4 +52,4 @@ function PointDisplay() {
   );
 }
 
-export default PointDisplay;
+export { PointDisplay };

--- a/src/app/_point/hooks/useScrollActivity.tsx
+++ b/src/app/_point/hooks/useScrollActivity.tsx
@@ -12,16 +12,21 @@ import {
   TOTAL_SCROLL_TIME_FOR_POINTS_MS,
 } from "@/lib/constants/point";
 
+interface UseScrollActivityProps {
+  mainRef: RefObject<HTMLElement | null>;
+  isEnabled?: boolean;
+}
+
 /**
  * 스크롤 감지 훅 (스크롤 시간 누적 및 포인트 지급)
  * @param mainRef - 스크롤 메인 요소 참조
  * @param isEnabled - 스크롤 감지 훅 활성화 여부 (기본값: true)
  * cart(장바구니) 도메인에서는 스크롤 감지 훅 비활성화
  */
-export function useScrollActivity(
-  mainRef: RefObject<HTMLElement | null>,
-  isEnabled: boolean = true
-) {
+export function useScrollActivity({
+  mainRef,
+  isEnabled = true,
+}: UseScrollActivityProps) {
   const {
     isScrolling,
     scrollTimeElapsed,

--- a/src/app/_point/hooks/useScrollActivity.tsx
+++ b/src/app/_point/hooks/useScrollActivity.tsx
@@ -23,7 +23,7 @@ interface UseScrollActivityProps {
  * @param isEnabled - 스크롤 감지 훅 활성화 여부 (기본값: true)
  * cart(장바구니) 도메인에서는 스크롤 감지 훅 비활성화
  */
-export function useScrollActivity({
+function useScrollActivity({
   mainRef,
   isEnabled = true,
 }: UseScrollActivityProps) {
@@ -113,3 +113,5 @@ export function useScrollActivity({
     }
   }, [isEnabled, scrollTimeElapsed, addPoints, resetScrollTimer]);
 }
+
+export default useScrollActivity;

--- a/src/app/_point/hooks/useScrollActivity.tsx
+++ b/src/app/_point/hooks/useScrollActivity.tsx
@@ -114,4 +114,4 @@ function useScrollActivity({
   }, [isEnabled, scrollTimeElapsed, addPoints, resetScrollTimer]);
 }
 
-export default useScrollActivity;
+export { useScrollActivity };

--- a/src/app/_shared/components/AppHeader.tsx
+++ b/src/app/_shared/components/AppHeader.tsx
@@ -13,7 +13,7 @@ import {
 import { ArrowLeft, ShoppingCart } from "lucide-react";
 
 import { useAppNavigation } from "@/app/_shared/hooks/useAppNavigation";
-import useCartStore from "@/app/cart/stores/useCartStore";
+import { useCartStore } from "@/app/cart/stores/useCartStore";
 
 const MAX_DISPLAY_CART_ITEMS = 99;
 
@@ -63,4 +63,4 @@ function AppHeader() {
   );
 }
 
-export default AppHeader;
+export { AppHeader };

--- a/src/app/_shared/components/AppNavbar.tsx
+++ b/src/app/_shared/components/AppNavbar.tsx
@@ -43,4 +43,4 @@ function AppNavbar() {
   );
 }
 
-export default AppNavbar;
+export { AppNavbar };

--- a/src/app/_shared/components/AppSwipeNavbar.tsx
+++ b/src/app/_shared/components/AppSwipeNavbar.tsx
@@ -55,4 +55,4 @@ function AppSwipeNavbar({ children }: SwipeContainerProps) {
   );
 }
 
-export default AppSwipeNavbar;
+export { AppSwipeNavbar };

--- a/src/app/_shared/components/ConditionalLayout.tsx
+++ b/src/app/_shared/components/ConditionalLayout.tsx
@@ -4,7 +4,7 @@ import { ReactNode, useRef } from "react";
 
 import { MAIN_CONTAINER } from "@/lib/styles";
 
-import { useScrollActivity } from "@/app/_point/hooks/useScrollActivity";
+import useScrollActivity from "@/app/_point/hooks/useScrollActivity";
 import { useAppNavigation } from "@/app/_shared/hooks/useAppNavigation";
 
 import PointDisplay from "@/app/_point/components/PointDisplay";

--- a/src/app/_shared/components/ConditionalLayout.tsx
+++ b/src/app/_shared/components/ConditionalLayout.tsx
@@ -20,7 +20,7 @@ function ConditionalLayout({ children }: ConditionalLayoutProps) {
   const mainRef = useRef<HTMLElement>(null);
   const isCartPage = currentPage === "cart";
 
-  useScrollActivity(mainRef, !isCartPage);
+  useScrollActivity({ mainRef, isEnabled: !isCartPage });
 
   return (
     <div className="h-full flex flex-col">

--- a/src/app/_shared/components/ConditionalLayout.tsx
+++ b/src/app/_shared/components/ConditionalLayout.tsx
@@ -5,7 +5,7 @@ import { ReactNode, useRef } from "react";
 import { MAIN_CONTAINER } from "@/lib/styles";
 
 import useScrollActivity from "@/app/_point/hooks/useScrollActivity";
-import { useAppNavigation } from "@/app/_shared/hooks/useAppNavigation";
+import useAppNavigation from "@/app/_shared/hooks/useAppNavigation";
 
 import PointDisplay from "@/app/_point/components/PointDisplay";
 import AppHeader from "@/app/_shared/components/AppHeader";

--- a/src/app/_shared/components/ConditionalLayout.tsx
+++ b/src/app/_shared/components/ConditionalLayout.tsx
@@ -4,12 +4,12 @@ import { ReactNode, useRef } from "react";
 
 import { MAIN_CONTAINER } from "@/lib/styles";
 
-import useScrollActivity from "@/app/_point/hooks/useScrollActivity";
-import useAppNavigation from "@/app/_shared/hooks/useAppNavigation";
+import { useScrollActivity } from "@/app/_point/hooks/useScrollActivity";
+import { useAppNavigation } from "@/app/_shared/hooks/useAppNavigation";
 
-import PointDisplay from "@/app/_point/components/PointDisplay";
-import AppHeader from "@/app/_shared/components/AppHeader";
-import AppNavbar from "@/app/_shared/components/AppNavbar";
+import { PointDisplay } from "@/app/_point/components/PointDisplay";
+import { AppHeader } from "@/app/_shared/components/AppHeader";
+import { AppNavbar } from "@/app/_shared/components/AppNavbar";
 
 interface ConditionalLayoutProps {
   children: ReactNode;

--- a/src/app/_shared/components/MainView.tsx
+++ b/src/app/_shared/components/MainView.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from "react";
 
 import { useAppNavigation } from "@/app/_shared/hooks/useAppNavigation";
 
-import AppSwipeNavbar from "@/app/_shared/components/AppSwipeNavbar";
+import { AppSwipeNavbar } from "@/app/_shared/components/AppSwipeNavbar";
 
 interface MainViewProps {
   shoppingHome: ReactNode;

--- a/src/app/_shared/components/MainView.tsx
+++ b/src/app/_shared/components/MainView.tsx
@@ -22,4 +22,4 @@ function MainView({ shoppingHome, deal }: MainViewProps) {
   );
 }
 
-export default MainView;
+export { MainView };

--- a/src/app/_shared/hooks/useAppNavigation.tsx
+++ b/src/app/_shared/hooks/useAppNavigation.tsx
@@ -22,4 +22,4 @@ function useAppNavigation() {
   };
 }
 
-export default useAppNavigation;
+export { useAppNavigation };

--- a/src/app/_shared/hooks/useAppNavigation.tsx
+++ b/src/app/_shared/hooks/useAppNavigation.tsx
@@ -1,10 +1,7 @@
 import { usePathname, useSearchParams } from "next/navigation";
 
-import {
-  MAIN_NAV_ITEMS,
-  NAV_ITEMS,
-  NavigationPage,
-} from "@/lib/constants/navigation";
+import { MAIN_NAV_ITEMS, NAV_ITEMS } from "@/lib/constants/navigation";
+import { NavigationPage } from "@/lib/types/navigationType";
 
 function useAppNavigation() {
   const pathname = usePathname();

--- a/src/app/_shared/hooks/useAppNavigation.tsx
+++ b/src/app/_shared/hooks/useAppNavigation.tsx
@@ -1,7 +1,8 @@
 import { usePathname, useSearchParams } from "next/navigation";
 
-import { MAIN_NAV_ITEMS, NAV_ITEMS } from "@/lib/constants/navigation";
 import { NavigationPage } from "@/lib/types/navigationType";
+
+import { MAIN_NAV_ITEMS, NAV_ITEMS } from "@/lib/constants/navigation";
 
 function useAppNavigation() {
   const pathname = usePathname();

--- a/src/app/_shared/hooks/useAppNavigation.tsx
+++ b/src/app/_shared/hooks/useAppNavigation.tsx
@@ -22,4 +22,4 @@ function useAppNavigation() {
   };
 }
 
-export { useAppNavigation };
+export default useAppNavigation;

--- a/src/app/cart/components/CartItem.tsx
+++ b/src/app/cart/components/CartItem.tsx
@@ -15,7 +15,7 @@ import { X } from "lucide-react";
 
 import { useCartStore } from "@/app/cart/stores/useCartStore";
 
-import { AddToCartQuantity } from "@/app/product/[id]/components/AddToCartQuantity";
+import { ProductQuantity } from "@/app/product/[id]/components/ProductQuantity";
 
 interface CartItemProps {
   item: CartItemType;
@@ -79,7 +79,7 @@ function CartItem({ item, onRemove }: CartItemProps) {
 
           <div onClick={(e) => e.stopPropagation()}>
             <FormProvider {...form}>
-              <AddToCartQuantity
+              <ProductQuantity
                 control={form.control}
                 maxPurchaseQuantity={getMaxPurchaseQuantity(
                   item.productOptions,

--- a/src/app/cart/components/CartItem.tsx
+++ b/src/app/cart/components/CartItem.tsx
@@ -13,7 +13,7 @@ import { OPTION_TEXT, TITLE } from "@/lib/styles";
 import { Button } from "@/ui/button";
 import { X } from "lucide-react";
 
-import useCartStore from "@/app/cart/stores/useCartStore";
+import { useCartStore } from "@/app/cart/stores/useCartStore";
 
 import ProductQuantity from "@/app/product/[id]/components/AddToCartQuantity";
 
@@ -102,4 +102,4 @@ function CartItem({ item, onRemove }: CartItemProps) {
   );
 }
 
-export default CartItem;
+export { CartItem };

--- a/src/app/cart/components/CartItem.tsx
+++ b/src/app/cart/components/CartItem.tsx
@@ -15,7 +15,7 @@ import { X } from "lucide-react";
 
 import { useCartStore } from "@/app/cart/stores/useCartStore";
 
-import ProductQuantity from "@/app/product/[id]/components/AddToCartQuantity";
+import { AddToCartQuantity } from "@/app/product/[id]/components/AddToCartQuantity";
 
 interface CartItemProps {
   item: CartItemType;
@@ -79,7 +79,7 @@ function CartItem({ item, onRemove }: CartItemProps) {
 
           <div onClick={(e) => e.stopPropagation()}>
             <FormProvider {...form}>
-              <ProductQuantity
+              <AddToCartQuantity
                 control={form.control}
                 maxPurchaseQuantity={getMaxPurchaseQuantity(
                   item.productOptions,

--- a/src/app/cart/components/CartItemList.tsx
+++ b/src/app/cart/components/CartItemList.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import useCartStore from "@/app/cart/stores/useCartStore";
+import { useCartStore } from "@/app/cart/stores/useCartStore";
 
-import CartItem from "@/app/cart/components/CartItem";
+import { CartItem } from "@/app/cart/components/CartItem";
 
 interface CartItemListProps {
   onProductRemove?: (itemId: string) => void;
-};
+}
 
 function CartItemList({ onProductRemove }: CartItemListProps) {
   const { items, removeFromCart } = useCartStore();
@@ -25,4 +25,4 @@ function CartItemList({ onProductRemove }: CartItemListProps) {
   );
 }
 
-export default CartItemList;
+export { CartItemList };

--- a/src/app/cart/components/CartSummary.tsx
+++ b/src/app/cart/components/CartSummary.tsx
@@ -4,7 +4,7 @@ import { formatPriceToKor } from "@/lib/utils";
 
 import { OPTION_TEXT, TITLE } from "@/lib/styles";
 
-import useCartStore from "@/app/cart/stores/useCartStore";
+import { useCartStore } from "@/app/cart/stores/useCartStore";
 
 function CartSummary() {
   const { totalItems, totalPrice } = useCartStore();
@@ -21,4 +21,4 @@ function CartSummary() {
   );
 }
 
-export default CartSummary;
+export { CartSummary };

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -13,12 +13,11 @@ import {
 } from "@/lib/styles";
 import { Button } from "@/ui/button";
 
+import { useUpdateStock } from "@/app/product/[id]/hooks/useUpdateStock";
 import { useCartStore } from "@/app/cart/stores/useCartStore";
 
 import { CartItemList } from "@/app/cart/components/CartItemList";
 import { CartSummary } from "@/app/cart/components/CartSummary";
-
-import { useUpdateStock } from "@/app/product/[id]/hooks/useUpdateStock";
 
 function CartPage() {
   const { items, totalItems, removeFromCart } = useCartStore();

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -18,7 +18,7 @@ import { useCartStore } from "@/app/cart/stores/useCartStore";
 import { CartItemList } from "@/app/cart/components/CartItemList";
 import { CartSummary } from "@/app/cart/components/CartSummary";
 
-import useUpdateStock from "../product/[id]/hooks/useUpdateStock";
+import { useUpdateStock } from "@/app/product/[id]/hooks/useUpdateStock";
 
 function CartPage() {
   const { items, totalItems, removeFromCart } = useCartStore();

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -13,10 +13,10 @@ import {
 } from "@/lib/styles";
 import { Button } from "@/ui/button";
 
-import useCartStore from "@/app/cart/stores/useCartStore";
+import { useCartStore } from "@/app/cart/stores/useCartStore";
 
-import CartItemList from "@/app/cart/components/CartItemList";
-import CartSummary from "@/app/cart/components/CartSummary";
+import { CartItemList } from "@/app/cart/components/CartItemList";
+import { CartSummary } from "@/app/cart/components/CartSummary";
 
 import useUpdateStock from "../product/[id]/hooks/useUpdateStock";
 

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -20,7 +20,7 @@ import { CartSummary } from "@/app/cart/components/CartSummary";
 
 import useUpdateStock from "../product/[id]/hooks/useUpdateStock";
 
-export default function CartPage() {
+function CartPage() {
   const { items, totalItems, removeFromCart } = useCartStore();
   const updateStockMutation = useUpdateStock();
 
@@ -78,3 +78,5 @@ export default function CartPage() {
     </div>
   );
 }
+
+export default CartPage;

--- a/src/app/cart/stores/useCartStore.tsx
+++ b/src/app/cart/stores/useCartStore.tsx
@@ -61,8 +61,7 @@ const useCartStore = create<CartStore>()(
         }
 
         const { items } = get();
-        const selectedOption =
-          createOptionsFromSelection(selectedOptions);
+        const selectedOption = createOptionsFromSelection(selectedOptions);
         const maxPurchaseQuantity = getMaxPurchaseQuantity(
           allAvailableOptions,
           selectedOption
@@ -79,7 +78,7 @@ const useCartStore = create<CartStore>()(
         const existingItemInCart = existingItemIndex !== -1;
         const isNewItem = existingItemIndex === -1;
 
-        if (existingItemInCart) { 
+        if (existingItemInCart) {
           const existingItem = updatedItems[existingItemIndex];
           const newQuantity = existingItem.quantity + quantity;
 
@@ -236,4 +235,4 @@ const useCartStore = create<CartStore>()(
   )
 );
 
-export default useCartStore;
+export { useCartStore };

--- a/src/app/cart/test/useCartStore.test.ts
+++ b/src/app/cart/test/useCartStore.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import useCartStore from "@/app/cart/stores/useCartStore";
+import { useCartStore } from "@/app/cart/stores/useCartStore";
 
 let uuidCounter = 0;
 vi.stubGlobal("crypto", {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
-import MainView from "@/app/_shared/components/MainView";
-import DealView from "@/app/product/_deal/components/DealView";
-import PersonalizedProductList from "@/app/product/components/PersonalizedProductList";
+import { MainView } from "@/app/_shared/components/MainView";
+import { DealView } from "@/app/product/_deal/components/DealView";
+import { PersonalizedProductList } from "@/app/product/components/PersonalizedProductList";
 
 interface HomeProps {
   searchParams: Promise<{

--- a/src/app/product/[id]/components/AddToCartForm.tsx
+++ b/src/app/product/[id]/components/AddToCartForm.tsx
@@ -11,8 +11,8 @@ import { Form } from "@/ui/form";
 import { useAddToCartForm } from "@/app/product/[id]/hooks/forms/useAddToCartForm";
 import { useUpdateStock } from "@/app/product/[id]/hooks/useUpdateStock";
 
-import { AddToCartOptions } from "@/app/product/[id]/components/AddToCartOptions";
-import { AddToCartQuantity } from "@/app/product/[id]/components/AddToCartQuantity";
+import { ProductOptions } from "@/app/product/[id]/components/ProductOptions";
+import { ProductQuantity } from "@/app/product/[id]/components/ProductQuantity";
 
 interface AddToCartFormProps {
   productDetail: ProductDetailInfo;
@@ -52,7 +52,7 @@ function AddToCartForm({ productDetail, onSuccess }: AddToCartFormProps) {
         onSubmit={addToCartForm.form.handleSubmit(addToCartForm.onSubmit)}
         className="p-4"
       >
-        <AddToCartOptions
+        <ProductOptions
           productOptions={addToCartForm.productOptions || []}
           control={addToCartForm.form.control}
           onSelectionChange={addToCartForm.handleOptionSelectionChange}
@@ -74,7 +74,7 @@ function AddToCartForm({ productDetail, onSuccess }: AddToCartFormProps) {
               </div>
 
               <div>
-                <AddToCartQuantity
+                <ProductQuantity
                   control={addToCartForm.form.control}
                   maxPurchaseQuantity={addToCartForm.maxPurchaseQuantity}
                   onQuantityChange={addToCartForm.handleQuantityChange}

--- a/src/app/product/[id]/components/AddToCartForm.tsx
+++ b/src/app/product/[id]/components/AddToCartForm.tsx
@@ -8,11 +8,11 @@ import { ADD_TO_CART_BOTTOM_CONTAINER, OPTION_TEXT, TITLE } from "@/lib/styles";
 import { Button } from "@/ui/button";
 import { Form } from "@/ui/form";
 
-import useAddToCartForm from "@/app/product/[id]/hooks/forms/useAddToCartForm";
-import useUpdateStock from "@/app/product/[id]/hooks/useUpdateStock";
+import { useAddToCartForm } from "@/app/product/[id]/hooks/forms/useAddToCartForm";
+import { useUpdateStock } from "@/app/product/[id]/hooks/useUpdateStock";
 
-import ProductOptions from "@/app/product/[id]/components/AddToCartOptions";
-import ProductQuantity from "@/app/product/[id]/components/AddToCartQuantity";
+import { AddToCartOptions } from "@/app/product/[id]/components/AddToCartOptions";
+import { AddToCartQuantity } from "@/app/product/[id]/components/AddToCartQuantity";
 
 type AddToCartFormProps = {
   productDetail: ProductDetailInfo;
@@ -52,7 +52,7 @@ function AddToCartForm({ productDetail, onSuccess }: AddToCartFormProps) {
         onSubmit={addToCartForm.form.handleSubmit(addToCartForm.onSubmit)}
         className="p-4"
       >
-        <ProductOptions
+        <AddToCartOptions
           productOptions={addToCartForm.productOptions || []}
           control={addToCartForm.form.control}
           onSelectionChange={addToCartForm.handleOptionSelectionChange}
@@ -74,7 +74,7 @@ function AddToCartForm({ productDetail, onSuccess }: AddToCartFormProps) {
               </div>
 
               <div>
-                <ProductQuantity
+                <AddToCartQuantity
                   control={addToCartForm.form.control}
                   maxPurchaseQuantity={addToCartForm.maxPurchaseQuantity}
                   onQuantityChange={addToCartForm.handleQuantityChange}
@@ -116,4 +116,4 @@ function AddToCartForm({ productDetail, onSuccess }: AddToCartFormProps) {
   );
 }
 
-export default AddToCartForm;
+export { AddToCartForm };

--- a/src/app/product/[id]/components/AddToCartForm.tsx
+++ b/src/app/product/[id]/components/AddToCartForm.tsx
@@ -14,10 +14,10 @@ import { useUpdateStock } from "@/app/product/[id]/hooks/useUpdateStock";
 import { AddToCartOptions } from "@/app/product/[id]/components/AddToCartOptions";
 import { AddToCartQuantity } from "@/app/product/[id]/components/AddToCartQuantity";
 
-type AddToCartFormProps = {
+interface AddToCartFormProps {
   productDetail: ProductDetailInfo;
   onSuccess?: () => void;
-};
+}
 
 function AddToCartForm({ productDetail, onSuccess }: AddToCartFormProps) {
   const addToCartForm = useAddToCartForm({ productDetail, onSuccess });

--- a/src/app/product/[id]/components/AddToCartOptions.tsx
+++ b/src/app/product/[id]/components/AddToCartOptions.tsx
@@ -17,7 +17,7 @@ import {
   SelectValue,
 } from "@/ui/select";
 
-import useProductOptions from "@/app/product/[id]/hooks/forms/useProductOptions";
+import { useProductOptions } from "@/app/product/[id]/hooks/forms/useProductOptions";
 
 interface AddToCartOptionsProps {
   productOptions: ProductOption[];
@@ -88,4 +88,4 @@ function AddToCartOptions({
   );
 }
 
-export default AddToCartOptions;
+export { AddToCartOptions };

--- a/src/app/product/[id]/components/AddToCartOptions.tsx
+++ b/src/app/product/[id]/components/AddToCartOptions.tsx
@@ -37,7 +37,7 @@ function AddToCartOptions({
     openDropdowns,
     handleOptionChange,
     handleDropdownToggle,
-  } = useProductOptions(productOptions, control);
+  } = useProductOptions({ productOptions, control });
 
   return (
     <div className="space-y-4">

--- a/src/app/product/[id]/components/AddToCartQuantity.tsx
+++ b/src/app/product/[id]/components/AddToCartQuantity.tsx
@@ -8,7 +8,7 @@ import { FormControl, FormField, FormItem, FormMessage } from "@/ui/form";
 import { Input } from "@/ui/input";
 import { MinusIcon, PlusIcon } from "lucide-react";
 
-import useProductQuantity from "@/app/product/[id]/hooks/forms/useProductQuantity";
+import { useProductQuantity } from "@/app/product/[id]/hooks/forms/useProductQuantity";
 
 interface AddToCartQuantityProps {
   control: Control<{ options: Record<string, string>; quantity: number }>;
@@ -80,4 +80,4 @@ function AddToCartQuantity({
   );
 }
 
-export default AddToCartQuantity;
+export { AddToCartQuantity };

--- a/src/app/product/[id]/components/ProductDescription.tsx
+++ b/src/app/product/[id]/components/ProductDescription.tsx
@@ -23,4 +23,4 @@ function ProductDescription({
   );
 }
 
-export default ProductDescription;
+export { ProductDescription };

--- a/src/app/product/[id]/components/ProductDescription.tsx
+++ b/src/app/product/[id]/components/ProductDescription.tsx
@@ -1,10 +1,10 @@
 import Image from "next/image";
 
-function ProductDescription({
-  descriptionImages,
-}: {
+interface ProductDescriptionProps {
   descriptionImages: string[];
-}) {
+}
+
+function ProductDescription({ descriptionImages }: ProductDescriptionProps) {
   return (
     <div className="bg-white">
       <div className="space-y-4">

--- a/src/app/product/[id]/components/ProductDetailView.tsx
+++ b/src/app/product/[id]/components/ProductDetailView.tsx
@@ -16,14 +16,14 @@ import {
   SheetTrigger,
 } from "@/ui/sheet";
 
-import useProductTab from "@/app/product/[id]/hooks/useProductTab";
-import useProductTabObserver from "@/app/product/[id]/hooks/useProductTabObserver";
+import { useProductTab } from "@/app/product/[id]/hooks/useProductTab";
+import { useProductTabObserver } from "@/app/product/[id]/hooks/useProductTabObserver";
 
-import AddToCartForm from "@/app/product/[id]/components/AddToCartForm";
-import ProductDescription from "@/app/product/[id]/components/ProductDescription";
-import ProductOverview from "@/app/product/[id]/components/ProductOverview";
-import ProductReview from "@/app/product/[id]/components/ProductReview";
-import ProductTab from "@/app/product/[id]/components/ProductTab";
+import { AddToCartForm } from "@/app/product/[id]/components/AddToCartForm";
+import { ProductDescription } from "@/app/product/[id]/components/ProductDescription";
+import { ProductOverview } from "@/app/product/[id]/components/ProductOverview";
+import { ProductReview } from "@/app/product/[id]/components/ProductReview";
+import { ProductTab } from "@/app/product/[id]/components/ProductTab";
 
 interface ProductDetailProps {
   productDetail: ProductDetailInfo;
@@ -111,4 +111,4 @@ function ProductDetailView({ productDetail }: ProductDetailProps) {
   );
 }
 
-export default ProductDetailView;
+export { ProductDetailView };

--- a/src/app/product/[id]/components/ProductOptions.tsx
+++ b/src/app/product/[id]/components/ProductOptions.tsx
@@ -25,7 +25,7 @@ interface AddToCartOptionsProps {
   onSelectionChange: (selectedOptions: Record<string, string>) => void;
 }
 
-function AddToCartOptions({
+function ProductOptions({
   productOptions,
   control,
   onSelectionChange,
@@ -88,4 +88,4 @@ function AddToCartOptions({
   );
 }
 
-export { AddToCartOptions };
+export { ProductOptions };

--- a/src/app/product/[id]/components/ProductOverview.tsx
+++ b/src/app/product/[id]/components/ProductOverview.tsx
@@ -3,10 +3,10 @@
 import { toProductPreview } from "@/lib/utils/productOptionUtils";
 import { ProductDetailInfo } from "@/lib/types/productType";
 
-import DealTimer from "@/app/product/_deal/components/DealTimer";
-import ProductImage from "@/app/product/components/ProductImage";
-import ProductPrice from "@/app/product/components/ProductPrice";
-import ProductRating from "@/app/product/components/ProductRating";
+import { DealTimer } from "@/app/product/_deal/components/DealTimer";
+import { ProductImage } from "@/app/product/components/ProductImage";
+import { ProductPrice } from "@/app/product/components/ProductPrice";
+import { ProductRating } from "@/app/product/components/ProductRating";
 
 interface ProductOverviewProps {
   productDetail: ProductDetailInfo;
@@ -39,4 +39,4 @@ function ProductOverview({ productDetail }: ProductOverviewProps) {
   );
 }
 
-export default ProductOverview;
+export { ProductOverview };

--- a/src/app/product/[id]/components/ProductQuantity.tsx
+++ b/src/app/product/[id]/components/ProductQuantity.tsx
@@ -18,7 +18,7 @@ interface AddToCartQuantityProps {
   showSelectedOptions?: boolean;
 }
 
-function AddToCartQuantity({
+function ProductQuantity({
   control,
   maxPurchaseQuantity = 0,
   onQuantityChange,
@@ -80,4 +80,4 @@ function AddToCartQuantity({
   );
 }
 
-export { AddToCartQuantity };
+export { ProductQuantity };

--- a/src/app/product/[id]/components/ProductReview.tsx
+++ b/src/app/product/[id]/components/ProductReview.tsx
@@ -6,7 +6,7 @@ import { Review } from "@/lib/types/productType";
 
 import { Button } from "@/ui/button";
 
-import ProductRating from "../../components/ProductRating";
+import { ProductRating } from "@/app/product/components/ProductRating";
 
 interface ProductReviewProps {
   reviews: Review[];
@@ -78,4 +78,4 @@ function ProductReview({ reviews }: ProductReviewProps) {
   );
 }
 
-export default ProductReview;
+export { ProductReview };

--- a/src/app/product/[id]/components/ProductTab.tsx
+++ b/src/app/product/[id]/components/ProductTab.tsx
@@ -43,4 +43,4 @@ function ProductTab({ activeTab, onTabChange, isVisible }: ProductTabProps) {
   );
 }
 
-export default ProductTab;
+export { ProductTab };

--- a/src/app/product/[id]/hooks/forms/useAddToCartForm.tsx
+++ b/src/app/product/[id]/hooks/forms/useAddToCartForm.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/lib/utils/productOptionUtils";
 import { ProductDetailInfo } from "@/lib/types/productType";
 
-import useCartStore from "@/app/cart/stores/useCartStore";
+import { useCartStore } from "@/app/cart/stores/useCartStore";
 
 interface UseAddToCartFormProps {
   productDetail: ProductDetailInfo;
@@ -124,4 +124,4 @@ function useAddToCartForm({ productDetail, onSuccess }: UseAddToCartFormProps) {
   };
 }
 
-export default useAddToCartForm;
+export { useAddToCartForm };

--- a/src/app/product/[id]/hooks/forms/useProductOptions.tsx
+++ b/src/app/product/[id]/hooks/forms/useProductOptions.tsx
@@ -100,4 +100,4 @@ function useProductOptions(
   };
 }
 
-export default useProductOptions;
+export { useProductOptions };

--- a/src/app/product/[id]/hooks/forms/useProductOptions.tsx
+++ b/src/app/product/[id]/hooks/forms/useProductOptions.tsx
@@ -7,10 +7,15 @@ import {
 } from "@/lib/utils/productOptionUtils";
 import { ProductOption } from "@/lib/types/productType";
 
-function useProductOptions(
-  productOptions: ProductOption[],
-  control: Control<{ options: Record<string, string>; quantity: number }>
-) {
+interface UseProductOptionsProps {
+  productOptions: ProductOption[];
+  control: Control<{ options: Record<string, string>; quantity: number }>;
+}
+
+function useProductOptions({
+  productOptions,
+  control,
+}: UseProductOptionsProps) {
   const optionKeys = useMemo(
     () => extractOptionKeys(productOptions),
     [productOptions]

--- a/src/app/product/[id]/hooks/forms/useProductQuantity.tsx
+++ b/src/app/product/[id]/hooks/forms/useProductQuantity.tsx
@@ -25,4 +25,4 @@ function useProductQuantity({
   };
 }
 
-export default useProductQuantity;
+export { useProductQuantity };

--- a/src/app/product/[id]/hooks/useProductTab.tsx
+++ b/src/app/product/[id]/hooks/useProductTab.tsx
@@ -3,13 +3,13 @@
 import { useEffect, useState } from "react";
 
 type ProductTabType = "reviews" | "details";
-interface UseProductTabReturn {
+interface UseProductTabProps {
   activeTab: ProductTabType;
   setActiveTab: (tab: ProductTabType) => void;
   isVisible: boolean;
 }
 
-const useProductTab = (): UseProductTabReturn => {
+const useProductTab = (): UseProductTabProps => {
   const [activeTab, setActiveTab] = useState<ProductTabType>("reviews");
   const [isVisible, setIsVisible] = useState(false);
 

--- a/src/app/product/[id]/hooks/useProductTab.tsx
+++ b/src/app/product/[id]/hooks/useProductTab.tsx
@@ -3,7 +3,11 @@
 import { useEffect, useState } from "react";
 
 type ProductTabType = "reviews" | "details";
-interface UseProductTabProps {
+interface UseProductTabReturn {
+  activeTab: ProductTabType;
+  setActiveTab: (tab: ProductTabType) => void;
+  isVisible: boolean;
+}
   activeTab: ProductTabType;
   setActiveTab: (tab: ProductTabType) => void;
   isVisible: boolean;

--- a/src/app/product/[id]/hooks/useProductTab.tsx
+++ b/src/app/product/[id]/hooks/useProductTab.tsx
@@ -30,4 +30,4 @@ const useProductTab = (): UseProductTabReturn => {
   };
 };
 
-export default useProductTab;
+export { useProductTab };

--- a/src/app/product/[id]/hooks/useProductTab.tsx
+++ b/src/app/product/[id]/hooks/useProductTab.tsx
@@ -8,12 +8,8 @@ interface UseProductTabReturn {
   setActiveTab: (tab: ProductTabType) => void;
   isVisible: boolean;
 }
-  activeTab: ProductTabType;
-  setActiveTab: (tab: ProductTabType) => void;
-  isVisible: boolean;
-}
 
-const useProductTab = (): UseProductTabProps => {
+const useProductTab = (): UseProductTabReturn => {
   const [activeTab, setActiveTab] = useState<ProductTabType>("reviews");
   const [isVisible, setIsVisible] = useState(false);
 

--- a/src/app/product/[id]/hooks/useProductTabObserver.tsx
+++ b/src/app/product/[id]/hooks/useProductTabObserver.tsx
@@ -47,4 +47,4 @@ const useProductTabObserver = ({
   }, [reviewRef, descriptionRef, setActiveTab]);
 };
 
-export default useProductTabObserver;
+export { useProductTabObserver };

--- a/src/app/product/[id]/hooks/useUpdateStock.tsx
+++ b/src/app/product/[id]/hooks/useUpdateStock.tsx
@@ -37,4 +37,4 @@ const useUpdateStock = () => {
   });
 };
 
-export default useUpdateStock;
+export { useUpdateStock };

--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -1,4 +1,4 @@
-import ProductDetailView from "@/app/product/[id]/components/ProductDetailView";
+import { ProductDetailView } from "@/app/product/[id]/components/ProductDetailView";
 
 import { fetchProductDetail } from "@/lib/api/productApi";
 

--- a/src/app/product/_deal/components/BrandProductList.tsx
+++ b/src/app/product/_deal/components/BrandProductList.tsx
@@ -1,4 +1,4 @@
-import ProductCard from "@/app/product/components/ProductCard";
+import { ProductCard } from "@/app/product/components/ProductCard";
 
 import { fetchProductPreviewInfo } from "@/lib/api/productsApi";
 

--- a/src/app/product/_deal/components/BrandProductList.tsx
+++ b/src/app/product/_deal/components/BrandProductList.tsx
@@ -20,4 +20,4 @@ async function BrandProductList() {
   );
 }
 
-export default BrandProductList;
+export { BrandProductList };

--- a/src/app/product/_deal/components/DailyProductList.tsx
+++ b/src/app/product/_deal/components/DailyProductList.tsx
@@ -1,4 +1,4 @@
-import ProductCard from "@/app/product/components/ProductCard";
+import { ProductCard } from "@/app/product/components/ProductCard";
 
 import { fetchProductPreviewInfo } from "@/lib/api/productsApi";
 

--- a/src/app/product/_deal/components/DailyProductList.tsx
+++ b/src/app/product/_deal/components/DailyProductList.tsx
@@ -27,4 +27,4 @@ async function DailyProductList() {
   );
 }
 
-export default DailyProductList;
+export { DailyProductList };

--- a/src/app/product/_deal/components/DealNavbar.tsx
+++ b/src/app/product/_deal/components/DealNavbar.tsx
@@ -59,4 +59,4 @@ function DealNavbar() {
   );
 }
 
-export default DealNavbar;
+export { DealNavbar };

--- a/src/app/product/_deal/components/DealTimer.tsx
+++ b/src/app/product/_deal/components/DealTimer.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect } from "react";
 
-import useDealTimerStore from "@/app/product/_deal/stores/useDealTimerStore";
+import { useDealTimerStore } from "@/app/product/_deal/stores/useDealTimerStore";
 
 function DealTimer() {
   const { timeLeft, progress, startTimer, stopTimer } = useDealTimerStore();
@@ -28,4 +28,4 @@ function DealTimer() {
   );
 }
 
-export default DealTimer;
+export { DealTimer };

--- a/src/app/product/_deal/components/DealView.tsx
+++ b/src/app/product/_deal/components/DealView.tsx
@@ -1,6 +1,6 @@
-import BrandProductList from "@/app/product/_deal/components/BrandProductList";
-import DailyProductList from "@/app/product/_deal/components/DailyProductList";
-import DealNavbar from "@/app/product/_deal/components/DealNavbar";
+import { BrandProductList } from "@/app/product/_deal/components/BrandProductList";
+import { DailyProductList } from "@/app/product/_deal/components/DailyProductList";
+import { DealNavbar } from "@/app/product/_deal/components/DealNavbar";
 
 interface DealViewProps {
   searchParams: {
@@ -21,4 +21,4 @@ function DealView({ searchParams }: DealViewProps) {
   );
 }
 
-export default DealView;
+export { DealView };

--- a/src/app/product/_deal/stores/useDealTimerStore.tsx
+++ b/src/app/product/_deal/stores/useDealTimerStore.tsx
@@ -71,4 +71,4 @@ const useDealTimerStore = create<DealTimerStore>((set, get) => ({
   },
 }));
 
-export default useDealTimerStore;
+export { useDealTimerStore };

--- a/src/app/product/components/PersonalizedProductList.tsx
+++ b/src/app/product/components/PersonalizedProductList.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 
-import ProductListSkeleton from "@/ui/ProductListSkeleton";
+import { ProductListSkeleton } from "@/ui/ProductListSkeleton";
 
 import { ProductCard } from "@/app/product/components/ProductCard";
 

--- a/src/app/product/components/PersonalizedProductList.tsx
+++ b/src/app/product/components/PersonalizedProductList.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 
 import ProductListSkeleton from "@/ui/ProductListSkeleton";
 
-import ProductCard from "@/app/product/components/ProductCard";
+import { ProductCard } from "@/app/product/components/ProductCard";
 
 import { fetchCustomers } from "@/lib/api/customerApi";
 import { fetchProductPreviewInfo } from "@/lib/api/productsApi";
@@ -28,4 +28,4 @@ async function PersonalizedProductList() {
   );
 }
 
-export default PersonalizedProductList;
+export { PersonalizedProductList };

--- a/src/app/product/components/ProductCard.tsx
+++ b/src/app/product/components/ProductCard.tsx
@@ -6,9 +6,9 @@ import { ProductPreviewInfo } from "@/lib/types/productType";
 
 import { OPTION_TEXT, TITLE } from "@/lib/styles";
 
-import DealTimer from "@/app/product/_deal/components/DealTimer";
-import ProductImage from "@/app/product/components/ProductImage";
-import ProductPrice from "@/app/product/components/ProductPrice";
+import { DealTimer } from "@/app/product/_deal/components/DealTimer";
+import { ProductImage } from "@/app/product/components/ProductImage";
+import { ProductPrice } from "@/app/product/components/ProductPrice";
 
 type ProductCardVariant = "default" | "daily_deal";
 interface ProductCardProps {
@@ -69,4 +69,4 @@ function ProductCard({ product, variant = "default" }: ProductCardProps) {
   );
 }
 
-export default ProductCard;
+export { ProductCard };

--- a/src/app/product/components/ProductImage.tsx
+++ b/src/app/product/components/ProductImage.tsx
@@ -28,4 +28,4 @@ function ProductImage({
   );
 }
 
-export default ProductImage;
+export { ProductImage };

--- a/src/app/product/components/ProductPrice.tsx
+++ b/src/app/product/components/ProductPrice.tsx
@@ -36,4 +36,4 @@ function ProductPrice({ product, size = "medium" }: ProductPriceProps) {
   }
 }
 
-export default ProductPrice;
+export { ProductPrice };

--- a/src/app/product/components/ProductRating.tsx
+++ b/src/app/product/components/ProductRating.tsx
@@ -32,4 +32,4 @@ function ProductRating({
   );
 }
 
-export default ProductRating;
+export { ProductRating };

--- a/src/lib/constants/navigation.ts
+++ b/src/lib/constants/navigation.ts
@@ -1,14 +1,6 @@
-export type NavigationPage = "home" | "product" | "cart" | "deal";
+import { NavItem } from "@/lib/types/navigationType";
 
-type NavItem = {
-  id: NavigationPage;
-  label: string;
-  href: string;
-  isMain: boolean;
-  match: (pathname: string, searchParams: URLSearchParams) => boolean;
-};
-
-export const NAV_ITEMS: NavItem[] = [
+const NAV_ITEMS: NavItem[] = [
   {
     id: "home",
     label: "쇼핑 홈",
@@ -44,4 +36,6 @@ export const NAV_ITEMS: NavItem[] = [
   },
 ];
 
-export const MAIN_NAV_ITEMS = NAV_ITEMS.filter((item) => item.isMain);
+const MAIN_NAV_ITEMS = NAV_ITEMS.filter((item) => item.isMain);
+
+export { MAIN_NAV_ITEMS, NAV_ITEMS };

--- a/src/lib/types/navigationType.ts
+++ b/src/lib/types/navigationType.ts
@@ -1,0 +1,11 @@
+type NavigationPage = "home" | "product" | "cart" | "deal";
+
+type NavItem = {
+  id: NavigationPage;
+  label: string;
+  href: string;
+  isMain: boolean;
+  match: (pathname: string, searchParams: URLSearchParams) => boolean;
+};
+
+export type { NavigationPage, NavItem };

--- a/src/ui/ProductListSkeleton.tsx
+++ b/src/ui/ProductListSkeleton.tsx
@@ -35,4 +35,4 @@ function ProductListSkeleton() {
   );
 }
 
-export default ProductListSkeleton;
+export { ProductListSkeleton };


### PR DESCRIPTION
## #️⃣연관된 이슈

- #57 

## 📝작업 내용
- 컴포넌트나 훅명을 그대로 사용하기 위해 export 방식은 named export 방식으로 통일
- navigation type과 constant 분리
- 확장 가능성을 고려하여 add to ... 형식의 컴포넌트명 product options 형태로 변경