### PR TITLE
refactor: product purchase와 cart의 상태를 동기화 하기 위해 react query 사용

### DIFF
--- a/src/app/_shared/hooks/useAppNavigation.tsx
+++ b/src/app/_shared/hooks/useAppNavigation.tsx
@@ -1,4 +1,5 @@
 import { usePathname, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
 
 import { NavigationPage } from "@/lib/types/navigationType";
 
@@ -8,14 +9,23 @@ function useAppNavigation() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const currentPage: NavigationPage =
-    NAV_ITEMS.find((item) => item.match(pathname, searchParams))?.id || "home";
+  const [navigationState, setNavigationState] = useState({
+    currentPage: "home" as NavigationPage,
+    isMainPage: true,
+  });
 
-  const isMainPage = MAIN_NAV_ITEMS.some((item) => item.id === currentPage);
+  useEffect(() => {
+    const currentPage: NavigationPage =
+      NAV_ITEMS.find((item) => item.match(pathname, searchParams))?.id ||
+      "home";
+
+    const isMainPage = MAIN_NAV_ITEMS.some((item) => item.id === currentPage);
+
+    setNavigationState({ currentPage, isMainPage });
+  }, [pathname, searchParams]);
 
   return {
-    currentPage,
-    isMainPage,
+    ...navigationState,
     mainNavItems: MAIN_NAV_ITEMS,
   };
 }

--- a/src/app/_shared/hooks/useAppNavigation.tsx
+++ b/src/app/_shared/hooks/useAppNavigation.tsx
@@ -1,5 +1,5 @@
-import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
 
 import { NavigationPage } from "@/lib/types/navigationType";
 

--- a/src/app/cart/components/CartItem.tsx
+++ b/src/app/cart/components/CartItem.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { FormProvider, useForm } from "react-hook-form";
 import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
 
 import { formatPriceToKor } from "@/lib/utils";
 import {
@@ -8,6 +9,7 @@ import {
   getMaxPurchaseQuantity,
 } from "@/lib/utils/productOptionUtils";
 import { CartItem as CartItemType } from "@/lib/types/cartType";
+import { fetchProductOptionsByProductId } from "@/lib/api/productApi";
 
 import { OPTION_TEXT, TITLE } from "@/lib/styles";
 import { Button } from "@/ui/button";
@@ -30,10 +32,25 @@ function CartItem({ item, onRemove }: CartItemProps) {
       quantity: item.quantity,
     },
   });
+
+  // 실시간으로 최신 productOptions 가져오기
+  const { data: latestProductOptions } = useQuery({
+    queryKey: ["productOptions", item.product.id],
+    queryFn: () => fetchProductOptionsByProductId(item.product.id),
+    staleTime: 1000 * 30, // 30초간 fresh 상태 유지 (자주 업데이트될 수 있으므로 짧게 설정)
+  });
+
+  // 최신 데이터가 있으면 사용, 없으면 기존 데이터 사용 (fallback)
+  const productOptionsToUse = latestProductOptions || item.productOptions;
+  const maxPurchaseQuantity = getMaxPurchaseQuantity(
+    productOptionsToUse,
+    selectedOptions
+  );
+
   const updateCartItemQuantity = useCartStore((state) => state.updateQuantity);
   const handleQuantityChange = (newQuantity: number) => {
     try {
-      updateCartItemQuantity(item.id, newQuantity, item.productOptions);
+      updateCartItemQuantity(item.id, newQuantity, productOptionsToUse);
       form.clearErrors("quantity");
     } catch (error) {
       const errorMessage =
@@ -81,10 +98,7 @@ function CartItem({ item, onRemove }: CartItemProps) {
             <FormProvider {...form}>
               <ProductQuantity
                 control={form.control}
-                maxPurchaseQuantity={getMaxPurchaseQuantity(
-                  item.productOptions,
-                  selectedOptions
-                )}
+                maxPurchaseQuantity={maxPurchaseQuantity}
                 selectedOptions={selectedOptions}
                 showSelectedOptions={false}
                 onQuantityChange={handleQuantityChange}

--- a/src/app/cart/components/CartItem.tsx
+++ b/src/app/cart/components/CartItem.tsx
@@ -9,7 +9,6 @@ import {
   getMaxPurchaseQuantity,
 } from "@/lib/utils/productOptionUtils";
 import { CartItem as CartItemType } from "@/lib/types/cartType";
-import { fetchProductOptionsByProductId } from "@/lib/api/productApi";
 
 import { OPTION_TEXT, TITLE } from "@/lib/styles";
 import { Button } from "@/ui/button";
@@ -18,6 +17,8 @@ import { X } from "lucide-react";
 import { useCartStore } from "@/app/cart/stores/useCartStore";
 
 import { ProductQuantity } from "@/app/product/components/ProductQuantity";
+
+import { fetchProductOptionsByProductId } from "@/lib/api/productApi";
 
 interface CartItemProps {
   item: CartItemType;

--- a/src/app/cart/components/CartItem.tsx
+++ b/src/app/cart/components/CartItem.tsx
@@ -34,24 +34,24 @@ function CartItem({ item, onRemove }: CartItemProps) {
     },
   });
 
-  // 실시간으로 최신 productOptions 가져오기
   const { data: latestProductOptions } = useQuery({
     queryKey: ["productOptions", item.product.id],
     queryFn: () => fetchProductOptionsByProductId(item.product.id),
-    staleTime: 1000 * 30, // 30초간 fresh 상태 유지 (자주 업데이트될 수 있으므로 짧게 설정)
+    staleTime: 1000 * 30,
   });
 
-  // 최신 데이터가 있으면 사용, 없으면 기존 데이터 사용 (fallback)
-  const productOptionsToUse = latestProductOptions || item.productOptions;
+  const productOptions = latestProductOptions?.length
+    ? latestProductOptions
+    : item.productOptions;
   const maxPurchaseQuantity = getMaxPurchaseQuantity(
-    productOptionsToUse,
+    productOptions,
     selectedOptions
   );
 
   const updateCartItemQuantity = useCartStore((state) => state.updateQuantity);
   const handleQuantityChange = (newQuantity: number) => {
     try {
-      updateCartItemQuantity(item.id, newQuantity, productOptionsToUse);
+      updateCartItemQuantity(item.id, newQuantity, productOptions);
       form.clearErrors("quantity");
     } catch (error) {
       const errorMessage =

--- a/src/app/product/[id]/components/ProductDetailView.tsx
+++ b/src/app/product/[id]/components/ProductDetailView.tsx
@@ -4,10 +4,7 @@ import { useRef, useState } from "react";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useQuery } from "@tanstack/react-query";
 
-import { fetchProductDetail } from "@/lib/api/productApi";
-
 import { CART_BOTTOM_CONTAINER } from "@/lib/styles";
-
 import { Button } from "@/ui/button";
 import {
   Sheet,
@@ -22,6 +19,8 @@ import { useProductTab } from "@/app/product/[id]/hooks/useProductTab";
 import { useProductTabObserver } from "@/app/product/[id]/hooks/useProductTabObserver";
 import { useProductPurchase } from "@/app/product/hooks/useProductPurchase";
 import { useCartStore } from "@/app/cart/stores/useCartStore";
+
+import { fetchProductDetail } from "@/lib/api/productApi";
 
 import { ProductActionForm } from "./ProductActionForm";
 import { ProductDescription } from "./ProductDescription";

--- a/src/app/product/[id]/components/ProductDetailView.tsx
+++ b/src/app/product/[id]/components/ProductDetailView.tsx
@@ -4,7 +4,6 @@ import { useRef, useState } from "react";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useQuery } from "@tanstack/react-query";
 
-import { ProductDetailInfo } from "@/lib/types/productType";
 import { fetchProductDetail } from "@/lib/api/productApi";
 
 import { CART_BOTTOM_CONTAINER } from "@/lib/styles";

--- a/src/app/product/[id]/components/ProductDetailView.tsx
+++ b/src/app/product/[id]/components/ProductDetailView.tsx
@@ -20,13 +20,13 @@ import { useProductTabObserver } from "@/app/product/[id]/hooks/useProductTabObs
 import { useProductPurchase } from "@/app/product/hooks/useProductPurchase";
 import { useCartStore } from "@/app/cart/stores/useCartStore";
 
-import { fetchProductDetail } from "@/lib/api/productApi";
+import { ProductActionForm } from "@/app/product/[id]/components/ProductActionForm";
+import { ProductDescription } from "@/app/product/[id]/components/ProductDescription";
+import { ProductOverview } from "@/app/product/[id]/components/ProductOverview";
+import { ProductReview } from "@/app/product/[id]/components/ProductReview";
+import { ProductTab } from "@/app/product/[id]/components/ProductTab";
 
-import { ProductActionForm } from "./ProductActionForm";
-import { ProductDescription } from "./ProductDescription";
-import { ProductOverview } from "./ProductOverview";
-import { ProductReview } from "./ProductReview";
-import { ProductTab } from "./ProductTab";
+import { fetchProductDetail } from "@/lib/api/productApi";
 
 interface ProductDetailProps {
   productId: string;

--- a/src/app/product/[id]/components/ProductDetailView.tsx
+++ b/src/app/product/[id]/components/ProductDetailView.tsx
@@ -87,12 +87,10 @@ function ProductDetailView({ productId }: ProductDetailProps) {
       );
       alert(`장바구니에 추가되었습니다.`);
       setIsSheetOpen(false);
-    } catch (e) {
-      if (e instanceof Error) {
-        alert(e.message);
-      } else {
-        alert("장바구니 추가 중 오류가 발생했습니다.");
-      }
+    } catch (error: unknown) {
+      alert(
+        error instanceof Error ? error.message : `장바구니 추가 중 오류가 발생했습니다.`
+      );
     }
   };
 
@@ -134,12 +132,10 @@ function ProductDetailView({ productId }: ProductDetailProps) {
       }
       alert(`구매 완료`);
       setIsSheetOpen(false);
-    } catch (e) {
-      if (e instanceof Error) {
-        alert(e.message);
-      } else {
-        alert("구매 중 오류가 발생했습니다.");
-      }
+    } catch (error: unknown) {
+      alert(
+        error instanceof Error ? error.message : `주문 중 오류가 발생했습니다.`
+      );
     }
   };
 

--- a/src/app/product/[id]/components/ProductDetailView.tsx
+++ b/src/app/product/[id]/components/ProductDetailView.tsx
@@ -85,7 +85,7 @@ function ProductDetailView({ productId }: ProductDetailProps) {
         productDetail.discount?.discountedPrice,
         productDetail.options
       );
-      alert("장바구니에 추가되었습니다.");
+      alert(`장바구니에 추가되었습니다.`);
       setIsSheetOpen(false);
     } catch (e) {
       if (e instanceof Error) {
@@ -132,7 +132,7 @@ function ProductDetailView({ productId }: ProductDetailProps) {
             );
         }
       }
-      alert("구매가 완료되었습니다!");
+      alert(`구매 완료`);
       setIsSheetOpen(false);
     } catch (e) {
       if (e instanceof Error) {

--- a/src/app/product/[id]/components/ProductDetailView.tsx
+++ b/src/app/product/[id]/components/ProductDetailView.tsx
@@ -100,6 +100,27 @@ function ProductDetailView({ productId }: ProductDetailProps) {
         optionId,
         quantityToDeduct: quantity,
       });
+
+      const cartItems = useCartStore.getState().items;
+      const existingCartItem = cartItems.find((item) => {
+        if (item.product.id !== productDetail.product.id) return false;
+        return item.selectedOptions.some((option) => option.id === optionId);
+      });
+
+      if (existingCartItem) {
+        const updatedQuantity = existingCartItem.quantity - quantity;
+        if (updatedQuantity <= 0) {
+          useCartStore.getState().removeFromCart(existingCartItem.id);
+        } else {
+          useCartStore
+            .getState()
+            .updateQuantity(
+              existingCartItem.id,
+              updatedQuantity,
+              productDetail.options
+            );
+        }
+      }
       alert("구매가 완료되었습니다!");
       setIsSheetOpen(false);
     } catch (e) {

--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -5,6 +5,7 @@ import {
 } from "@tanstack/react-query";
 
 import { ProductDetailView } from "@/app/product/[id]/components/ProductDetailView";
+
 import { fetchProductDetail } from "@/lib/api/productApi";
 
 interface ProductPageProps {

--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -1,4 +1,11 @@
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from "@tanstack/react-query";
+
 import { ProductDetailView } from "@/app/product/[id]/components/ProductDetailView";
+import { fetchProductDetail } from "@/lib/api/productApi";
 
 interface ProductPageProps {
   params: Promise<{
@@ -9,9 +16,23 @@ interface ProductPageProps {
 async function ProductPage(props: ProductPageProps) {
   const { id: productId } = await props.params;
 
+  const queryClient = new QueryClient();
+
+  try {
+    await queryClient.prefetchQuery({
+      queryKey: ["productDetail", productId],
+      queryFn: () => fetchProductDetail(productId),
+      staleTime: 1000 * 60 * 5,
+    });
+  } catch (error) {
+    console.error(`fetch product detailerror: ${error}`);
+  }
+
   return (
     <div className="min-h-screen bg-gray-50">
-      <ProductDetailView productId={productId} />
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <ProductDetailView productId={productId} />
+      </HydrationBoundary>
     </div>
   );
 }

--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -1,7 +1,5 @@
 import { ProductDetailView } from "@/app/product/[id]/components/ProductDetailView";
 
-import { fetchProductDetail } from "@/lib/api/productApi";
-
 interface ProductPageProps {
   params: Promise<{
     id: string;
@@ -9,25 +7,13 @@ interface ProductPageProps {
 }
 
 async function ProductPage(props: ProductPageProps) {
-  try {
-    const { id: productId } = await props.params;
-    const productDetail = await fetchProductDetail(productId);
+  const { id: productId } = await props.params;
 
-    return (
-      <div className="min-h-screen bg-gray-50">
-        <ProductDetailView
-          productDetail={productDetail}
-          productId={productId}
-        />
-      </div>
-    );
-  } catch {
-    return (
-      <div className="flex justify-center items-center h-screen">
-        <div>상품을 불러올 수 없습니다.</div>
-      </div>
-    );
-  }
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <ProductDetailView productId={productId} />
+    </div>
+  );
 }
 
 export default ProductPage;

--- a/src/app/product/hooks/forms/useProductQuantity.tsx
+++ b/src/app/product/hooks/forms/useProductQuantity.tsx
@@ -1,4 +1,5 @@
-import { Control, useWatch } from "react-hook-form";
+import { Control, useController } from "react-hook-form";
+import { useEffect } from "react";
 
 interface UseProductQuantityProps {
   control: Control<{ options: Record<string, string>; quantity: number }>;
@@ -11,7 +12,19 @@ function useProductQuantity({
   max,
   onChange,
 }: UseProductQuantityProps) {
-  const quantity = useWatch({ control, name: "quantity" });
+  const {
+    field: { value: quantity, onChange: fieldOnChange },
+  } = useController({
+    control,
+    name: "quantity",
+  });
+
+  useEffect(() => {
+    if (max > 0 && quantity > max) {
+      fieldOnChange(max);
+      onChange?.(max);
+    }
+  }, [max, quantity, fieldOnChange, onChange]);
 
   const setQuantity = (next: number, update: (value: number) => void) => {
     if (next < 1 || (max > 0 && next > max)) return;

--- a/src/app/product/hooks/forms/useProductQuantity.tsx
+++ b/src/app/product/hooks/forms/useProductQuantity.tsx
@@ -1,5 +1,5 @@
-import { Control, useController } from "react-hook-form";
 import { useEffect } from "react";
+import { Control, useController } from "react-hook-form";
 
 interface UseProductQuantityProps {
   control: Control<{ options: Record<string, string>; quantity: number }>;

--- a/src/app/product/hooks/useProductPurchase.tsx
+++ b/src/app/product/hooks/useProductPurchase.tsx
@@ -24,9 +24,6 @@ function useProductPurchase() {
 
       productIds.forEach((productId) => {
         queryClient.invalidateQueries({
-          queryKey: ["productOptions", productId],
-        });
-        queryClient.invalidateQueries({
           queryKey: ["productDetail", productId],
         });
       });

--- a/src/app/product/hooks/useProductPurchase.tsx
+++ b/src/app/product/hooks/useProductPurchase.tsx
@@ -23,8 +23,13 @@ function useProductPurchase() {
       ];
 
       productIds.forEach((productId) => {
+        // 상품 상세 페이지용 쿼리 무효화
         queryClient.invalidateQueries({
           queryKey: ["productDetail", productId],
+        });
+        // 장바구니용 productOptions 쿼리 무효화
+        queryClient.invalidateQueries({
+          queryKey: ["productOptions", productId],
         });
       });
     },

--- a/src/lib/api/productApi.ts
+++ b/src/lib/api/productApi.ts
@@ -157,10 +157,16 @@ export const purchaseProduct = async (
       throw new Error(`상품 재고가 부족합니다.`);
     }
 
-    // 재고 차감
+    if (currentOption.maxPurchaseQuantity < quantityToDeduct) {
+      throw new Error(
+        `최대 구매 가능 수량을 초과했습니다. 현재 최대 구매 가능 수량: ${currentOption.maxPurchaseQuantity}개`
+      );
+    }
+
     const updatedOption = {
       ...currentOption,
       stockQuantity: currentOption.stockQuantity - quantityToDeduct,
+      maxPurchaseQuantity: currentOption.maxPurchaseQuantity - quantityToDeduct,
     };
 
     const updateResponse = await fetch(

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -8,13 +8,13 @@ export function cn(...inputs: ClassValue[]) {
 const getApiUrl = (endpoint: string) => {
   // 서버 측
   if (typeof window === "undefined") {
-    const apiBaseUrl = "http://localhost:3001";
+    const apiBaseUrl = process.env.API_BASE_URL;
     if (apiBaseUrl) {
-      return `${apiBaseUrl}/${endpoint}`;
+      return `${apiBaseUrl}/api/${endpoint}`;
     }
   }
   // 클라이언트 측에선 상대 경로
-  return `http://localhost:3001/${endpoint}`;
+  return `/api/${endpoint}`;
 };
 
 const formatPriceToKor = (price: number) => {

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -8,13 +8,13 @@ export function cn(...inputs: ClassValue[]) {
 const getApiUrl = (endpoint: string) => {
   // 서버 측
   if (typeof window === "undefined") {
-    const apiBaseUrl = process.env.API_BASE_URL;
+    const apiBaseUrl = "http://localhost:3001";
     if (apiBaseUrl) {
-      return `${apiBaseUrl}/api/${endpoint}`;
+      return `${apiBaseUrl}/${endpoint}`;
     }
   }
   // 클라이언트 측에선 상대 경로
-  return `/api/${endpoint}`;
+  return `http://localhost:3001/${endpoint}`;
 };
 
 const formatPriceToKor = (price: number) => {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #68

## 📝작업 내용

- product purchase api PATCH options에 max purchase quantity 추가
- product detail에서 상품 구매와 장바구니 상태를 동시에 업데이트 하기 위해 react query를 적용
- 이 과정에서 클라이언트 <-> 서버 간의 데이터 불일치 문제(hydration mismatch)를 해결하기 위해 HydrationBoundary를 사용
- product quantity hook의 useWatch를 제어하기 위해 useController로 변경
- useAppNavigation hook이 Router Context를 못 찾는 문제를 해결하기 위해 무조건 클라이언트에서 컴포넌트가 마운트 되는 useEffect로 useSearchParams와 usePathname의 상태를 감싸줌
