### PR TITLE
fix: product tab observer threshold 값 조정 및 use scroll activity props 수정

### DIFF
--- a/src/_shared/modules/point/hooks/useScrollActivity.tsx
+++ b/src/_shared/modules/point/hooks/useScrollActivity.tsx
@@ -14,19 +14,13 @@ import {
 
 interface UseScrollActivityProps {
   mainRef: RefObject<HTMLElement | null>;
-  isEnabled?: boolean;
 }
 
 /**
  * 스크롤 감지 훅 (스크롤 시간 누적 및 포인트 지급)
  * @param mainRef - 스크롤 메인 요소 참조
- * @param isEnabled - 스크롤 감지 훅 활성화 여부 (기본값: true)
- * cart(장바구니) 도메인에서는 스크롤 감지 훅 비활성화
  */
-function useScrollActivity({
-  mainRef,
-  isEnabled = true,
-}: UseScrollActivityProps) {
+function useScrollActivity({ mainRef }: UseScrollActivityProps) {
   const {
     isScrolling,
     scrollTimeElapsed,
@@ -44,7 +38,7 @@ function useScrollActivity({
    * 스크롤 이벤트 핸들러
    */
   const scrollHandler = useCallback(() => {
-    if (!isEnabled || !mainRef.current) return;
+    if (!mainRef.current) return;
 
     const currentScrollPosition = mainRef.current.scrollTop;
     const delta = Math.abs(currentScrollPosition - lastScrollPosition.current);
@@ -58,7 +52,7 @@ function useScrollActivity({
         SCROLL_INACTIVITY_THRESHOLD_MS
       );
     }
-  }, [isEnabled, mainRef, pauseScrollTimer, startScrollTimer]);
+  }, [mainRef, pauseScrollTimer, startScrollTimer]);
 
   /**
    * 스크롤 이벤트 핸들러를 throttle 처리
@@ -72,7 +66,7 @@ function useScrollActivity({
    * 스크롤 이벤트 등록
    */
   useEffect(() => {
-    if (!isEnabled || !mainRef.current) return;
+    if (!mainRef.current) return;
 
     const el = mainRef.current;
     lastScrollPosition.current = el.scrollTop;
@@ -86,32 +80,32 @@ function useScrollActivity({
       throttledScrollHandler.cancel(); // 대기 중인 throttle 취소
       clearTimeout(inactivityTimeout.current);
     };
-  }, [isEnabled, mainRef, throttledScrollHandler]);
+  }, [mainRef, throttledScrollHandler]);
 
   /**
    * 타이머로 시간 누적
    */
   useEffect(() => {
-    if (!isEnabled || !isScrolling) return;
+    if (!isScrolling) return;
 
     const intervalId = window.setInterval(() => {
       incrementScrollTime(SCROLL_POINT_GAIN_INTERVAL_MS);
     }, SCROLL_POINT_GAIN_INTERVAL_MS);
 
     return () => clearInterval(intervalId);
-  }, [isEnabled, isScrolling, incrementScrollTime]);
+  }, [isScrolling, incrementScrollTime]);
 
   /**
    * 포인트 지급
    */
   useEffect(() => {
-    if (!isEnabled || scrollTimeElapsed < TOTAL_SCROLL_TIME_FOR_POINTS_MS) {
+    if (scrollTimeElapsed < TOTAL_SCROLL_TIME_FOR_POINTS_MS) {
       return;
     } else {
       addPoints(POINTS_PER_INTERVAL);
       resetScrollTimer();
     }
-  }, [isEnabled, scrollTimeElapsed, addPoints, resetScrollTimer]);
+  }, [scrollTimeElapsed, addPoints, resetScrollTimer]);
 }
 
 export { useScrollActivity };

--- a/src/_shared/modules/product/components/ProductDescription.tsx
+++ b/src/_shared/modules/product/components/ProductDescription.tsx
@@ -6,15 +6,19 @@ interface ProductDescriptionProps {
 
 function ProductDescription({ descriptionImages }: ProductDescriptionProps) {
   return (
-    <div className="bg-white">
+    <div>
       <div className="space-y-4">
         {descriptionImages.map((imageUrl) => (
-          <div key={imageUrl} className="w-full h-auto">
+          <div
+            key={imageUrl}
+            className="w-full min-h-[700px] relative overflow-hidden bg-gray-200"
+          >
             <Image
               src={imageUrl}
-              alt={`제품 상세 이미지`}
-              width={468}
-              height={0}
+              alt="제품 상세 이미지"
+              fill
+              className="object-contain"
+              sizes="(max-width: 768px) 100vw, 768px"
             />
           </div>
         ))}

--- a/src/_shared/modules/product/hooks/useProductTabObserver.tsx
+++ b/src/_shared/modules/product/hooks/useProductTabObserver.tsx
@@ -9,7 +9,7 @@ interface UseProductTabObserverProps {
 }
 
 const ROOT_MARGIN = "0px 0px -10% 0px";
-const INTERSECTION_THRESHOLD = 0.1;
+const INTERSECTION_THRESHOLD = 0.3;
 
 const useProductTabObserver = ({
   reviewRef,

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -17,7 +17,7 @@ interface MainLayoutProps {
 export default function MainLayout({ children }: MainLayoutProps) {
   const mainRef = useRef<HTMLElement>(null);
 
-  useScrollActivity({ mainRef, isEnabled: true });
+  useScrollActivity({ mainRef });
 
   return (
     <div className="h-full flex flex-col">

--- a/src/app/product/[id]/layout.tsx
+++ b/src/app/product/[id]/layout.tsx
@@ -16,7 +16,7 @@ interface ProductLayoutProps {
 export default function ProductLayout({ children }: ProductLayoutProps) {
   const mainRef = useRef<HTMLElement>(null);
 
-  useScrollActivity({ mainRef, isEnabled: true });
+  useScrollActivity({ mainRef });
 
   return (
     <div className="h-full flex flex-col">


### PR DESCRIPTION
## #️⃣연관된 이슈
- #79
- #84 

## 📝작업 내용
### product tab observer
- product detail page에서 description image의 heigth는 항상 700으로 고정된 값을 갖도록
- observer의 threshold 값은 0.1에서 0.3으로 조정 -> 0.1은 너무 민감해서 상태 변환이 잦음
### use scroll activity
- 라우팅별로 레이아웃을 두며 use scroll activity에서 cart 페이지인지, 아닌지를 감지하는 isEnabled props는 더 이상 사용되지 않기에 제거