### PR TITLE
feat: product list에서도 장바구니 담기

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,28 +1,6 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  images: {
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "picsum.photos",
-        port: "",
-        pathname: "/**",
-      },
-      {
-        protocol: "https",
-        hostname: "loremflickr.com",
-        port: "",
-        pathname: "/**",
-      },
-      {
-        protocol: "https",
-        hostname: "i.pinimg.com",
-        port: "",
-        pathname: "/**",
-      },
-    ],
-  },
   async rewrites() {
     return [
       {

--- a/next.config.ts
+++ b/next.config.ts
@@ -23,6 +23,14 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: "https://back-shopping-app.vercel.app/api/:path*",
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/_shared/modules/deal/components/DailyProductCard.tsx
+++ b/src/_shared/modules/deal/components/DailyProductCard.tsx
@@ -1,14 +1,17 @@
 "use client";
 
+import { MouseEvent, useState } from "react";
+import Link from "next/link";
+
+import { ProductPreviewInfo } from "@/lib/types/productType";
+
+import { OPTION_TEXT, TITLE } from "@/lib/styles";
+
+import { DealTimer } from "@/_shared/modules/deal/components/DealTimer";
 import { AddToCartButton } from "@/_shared/modules/product/components/AddToCartButton";
 import { AddToCartSheet } from "@/_shared/modules/product/components/AddToCartSheet";
 import { ProductImage } from "@/_shared/modules/product/components/ProductImage";
 import { ProductPrice } from "@/_shared/modules/product/components/ProductPrice";
-import { OPTION_TEXT, TITLE } from "@/lib/styles";
-import { ProductPreviewInfo } from "@/lib/types/productType";
-import Link from "next/link";
-import { MouseEvent, useState } from "react";
-import { DealTimer } from "@/_shared/modules/deal/components/DealTimer";
 
 interface ProductCardProps {
   product: ProductPreviewInfo;

--- a/src/_shared/modules/deal/components/DailyProductCard.tsx
+++ b/src/_shared/modules/deal/components/DailyProductCard.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { AddToCartButton } from "@/_shared/modules/product/components/AddToCartButton";
+import { AddToCartSheet } from "@/_shared/modules/product/components/AddToCartSheet";
+import { ProductImage } from "@/_shared/modules/product/components/ProductImage";
+import { ProductPrice } from "@/_shared/modules/product/components/ProductPrice";
+import { OPTION_TEXT, TITLE } from "@/lib/styles";
+import { ProductPreviewInfo } from "@/lib/types/productType";
+import Link from "next/link";
+import { MouseEvent, useState } from "react";
+import { DealTimer } from "@/_shared/modules/deal/components/DealTimer";
+
+interface ProductCardProps {
+  product: ProductPreviewInfo;
+}
+
+function DailyProductCard({ product }: ProductCardProps) {
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+
+  const handleAddToCartClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsSheetOpen(true);
+  };
+
+  return (
+    <li>
+      <Link href={`/product/${product.id}`}>
+        <div className="flex-shrink-0 w-full rounded-lg overflow-hidden">
+          <div className="relative h-48 w-full rounded-t-lg overflow-hidden">
+            <ProductImage product={product} />
+            <div className="absolute top-2 right-2 z-10">
+              <AddToCartButton onClick={handleAddToCartClick} />
+            </div>
+          </div>
+          <div className="p-4">
+            <h3 className={TITLE}>{product.name}</h3>
+            <div className="flex items-center justify-between">
+              <ProductPrice product={product} size="large" />
+              <div className="flex items-center">
+                <span className="text-yellow-400">★</span>
+                <span className={OPTION_TEXT}>
+                  {product.averageRating} ({product.reviewCount})
+                </span>
+              </div>
+            </div>
+            <div>
+              <DealTimer />
+            </div>
+          </div>
+        </div>
+      </Link>
+      <AddToCartSheet
+        productId={product.id}
+        isOpen={isSheetOpen}
+        onOpenChange={setIsSheetOpen}
+      />
+    </li>
+  );
+}
+
+export { DailyProductCard };

--- a/src/_shared/modules/deal/components/DailyProductList.tsx
+++ b/src/_shared/modules/deal/components/DailyProductList.tsx
@@ -1,45 +1,10 @@
-import Link from "next/link";
-
 import { ProductPreviewInfo } from "@/lib/types/productType";
 
-import { OPTION_TEXT, TITLE } from "@/lib/styles";
-
-import { DealTimer } from "@/_shared/modules/deal/components/DealTimer";
-import { ProductImage } from "@/_shared/modules/product/components/ProductImage";
-import { ProductPrice } from "@/_shared/modules/product/components/ProductPrice";
-
+import { DailyProductCard } from "./DailyProductCard";
 import { fetchProductPreviewInfo } from "@/lib/api/productsApi";
+
 interface ProductCardProps {
   product: ProductPreviewInfo;
-}
-
-function DailyProductCard({ product }: ProductCardProps) {
-  return (
-    <li>
-      <Link href={`/product/${product.id}`}>
-        <div className="flex-shrink-0 w-full rounded-lg overflow-hidden">
-          <div className="relative h-48 w-full rounded-t-lg overflow-hidden">
-            <ProductImage product={product} />
-          </div>
-          <div className="p-4">
-            <h3 className={TITLE}>{product.name}</h3>
-            <div className="flex items-center justify-between">
-              <ProductPrice product={product} size="large" />
-              <div className="flex items-center">
-                <span className="text-yellow-400">★</span>
-                <span className={OPTION_TEXT}>
-                  {product.averageRating} ({product.reviewCount})
-                </span>
-              </div>
-            </div>
-            <div>
-              <DealTimer />
-            </div>
-          </div>
-        </div>
-      </Link>
-    </li>
-  );
 }
 
 async function DailyProductList() {

--- a/src/_shared/modules/deal/components/DailyProductList.tsx
+++ b/src/_shared/modules/deal/components/DailyProductList.tsx
@@ -1,11 +1,5 @@
-import { ProductPreviewInfo } from "@/lib/types/productType";
-
-import { DailyProductCard } from "./DailyProductCard";
+import { DailyProductCard } from "@/_shared/modules/deal/components/DailyProductCard";
 import { fetchProductPreviewInfo } from "@/lib/api/productsApi";
-
-interface ProductCardProps {
-  product: ProductPreviewInfo;
-}
 
 async function DailyProductList() {
   const products = await fetchProductPreviewInfo();

--- a/src/_shared/modules/deal/components/DailyProductList.tsx
+++ b/src/_shared/modules/deal/components/DailyProductList.tsx
@@ -1,4 +1,5 @@
 import { DailyProductCard } from "@/_shared/modules/deal/components/DailyProductCard";
+
 import { fetchProductPreviewInfo } from "@/lib/api/productsApi";
 
 async function DailyProductList() {

--- a/src/_shared/modules/product/components/AddToCartButton.tsx
+++ b/src/_shared/modules/product/components/AddToCartButton.tsx
@@ -1,6 +1,8 @@
-import { Button } from "@/_shared/components/button";
-import { ShoppingCart } from "lucide-react";
 import { MouseEventHandler } from "react";
+
+import { ShoppingCart } from "lucide-react";
+
+import { Button } from "@/_shared/components/button";
 
 interface AddToCartButtonProps {
   onClick?: MouseEventHandler<HTMLButtonElement>;
@@ -29,7 +31,6 @@ function AddToCartButton({
       aria-label="장바구니에 추가"
     >
       <ShoppingCart className="h-4 w-4" />
-      <span className="sr-only">장바구니에 추가</span>
     </Button>
   );
 }

--- a/src/_shared/modules/product/components/AddToCartButton.tsx
+++ b/src/_shared/modules/product/components/AddToCartButton.tsx
@@ -6,19 +6,10 @@ import { Button } from "@/_shared/components/button";
 
 interface AddToCartButtonProps {
   onClick?: MouseEventHandler<HTMLButtonElement>;
-  isDisabled?: boolean;
 }
 
-function AddToCartButton({
-  onClick,
-  isDisabled = false,
-}: AddToCartButtonProps) {
+function AddToCartButton({ onClick }: AddToCartButtonProps) {
   const handleButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    if (isDisabled) {
-      event.preventDefault();
-      event.stopPropagation();
-      return;
-    }
     onClick?.(event);
   };
 

--- a/src/_shared/modules/product/components/AddToCartButton.tsx
+++ b/src/_shared/modules/product/components/AddToCartButton.tsx
@@ -1,0 +1,37 @@
+import { Button } from "@/_shared/components/button";
+import { ShoppingCart } from "lucide-react";
+import { MouseEventHandler } from "react";
+
+interface AddToCartButtonProps {
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  isDisabled?: boolean;
+}
+
+function AddToCartButton({
+  onClick,
+  isDisabled = false,
+}: AddToCartButtonProps) {
+  const handleButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (isDisabled) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+    onClick?.(event);
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className="p-2 h-8 w-8 hover:bg-blue-50 hover:border-blue-200"
+      onClick={handleButtonClick}
+      aria-label="장바구니에 추가"
+    >
+      <ShoppingCart className="h-4 w-4" />
+      <span className="sr-only">장바구니에 추가</span>
+    </Button>
+  );
+}
+
+export { AddToCartButton };

--- a/src/_shared/modules/product/components/AddToCartForm.tsx
+++ b/src/_shared/modules/product/components/AddToCartForm.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { cn, formatPriceToKor } from "@/lib/utils";
+import { notification } from "@/lib/utils/notification";
+import { convertRecordToKeyValueArray } from "@/lib/utils/productOptionUtils";
+import { ProductDetailInfo } from "@/lib/types/productType";
+
+import { ADD_TO_CART_BOTTOM_CONTAINER, OPTION_TEXT, TITLE } from "@/lib/styles";
+
+import { useProductActionForm } from "@/_shared/modules/product/hooks/forms/useProductActionForm";
+
+import { Button } from "@/_shared/components/button";
+import { Form } from "@/_shared/components/form";
+import { ProductOptions } from "@/_shared/modules/product/components/ProductOptions";
+import { ProductQuantity } from "@/_shared/modules/product/components/ProductQuantity";
+
+import { ERROR_MESSAGE } from "@/lib/constants/message";
+
+interface AddToCartFormProps {
+  productDetail: ProductDetailInfo;
+  onAddToCart?: (optionId: string, quantity: number) => void;
+}
+
+function AddToCartForm({ productDetail, onAddToCart }: AddToCartFormProps) {
+  const {
+    form,
+    productOptions,
+    watchedOptions,
+    watchedQuantity,
+    totalAmount,
+    maxBuyQuantity,
+    allOptionsSelected,
+    currentMatchingOption,
+    handleOptionChange,
+    handleQuantityChange,
+  } = useProductActionForm({
+    productDetail,
+  });
+
+  function handleAddToCartClick() {
+    if (!allOptionsSelected || !currentMatchingOption) {
+      notification.error(ERROR_MESSAGE.MISSING_OPTIONS);
+      return;
+    }
+    try {
+      onAddToCart?.(currentMatchingOption.id, watchedQuantity);
+    } catch {
+      notification.error(ERROR_MESSAGE.ADD_TO_CART_ERROR);
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form className="p-4">
+        <ProductOptions
+          productOptions={productOptions || []}
+          control={form.control}
+          onSelectionChange={handleOptionChange}
+        />
+
+        <div className="space-y-4 pt-4">
+          <div className="bg-gray-50 p-4 rounded-lg">
+            <span className={OPTION_TEXT}>선택한 옵션</span>
+            <div className="flex items-start justify-between">
+              <div className="flex flex-wrap">
+                {convertRecordToKeyValueArray(watchedOptions).map((option) => (
+                  <span key={option.key} className={cn(OPTION_TEXT, "mr-2")}>
+                    {option.key}: {option.value}
+                  </span>
+                ))}
+              </div>
+              <div>
+                <ProductQuantity
+                  control={form.control}
+                  maxBuyQuantity={maxBuyQuantity}
+                  onQuantityChange={handleQuantityChange}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className={ADD_TO_CART_BOTTOM_CONTAINER}>
+          <div className="flex items-center justify-between mb-4">
+            <span className={OPTION_TEXT}>상품 금액</span>
+            <span className={TITLE}>{formatPriceToKor(totalAmount)}원</span>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              className="flex-1 h-12 text-lg font-bold"
+              disabled={!allOptionsSelected}
+              onClick={handleAddToCartClick}
+            >
+              장바구니
+            </Button>
+          </div>
+        </div>
+      </form>
+    </Form>
+  );
+}
+
+export { AddToCartForm };

--- a/src/_shared/modules/product/components/AddToCartSheet.tsx
+++ b/src/_shared/modules/product/components/AddToCartSheet.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { fetchProductDetail } from "@/lib/api/productApi";
+import { useCartStore } from "@/_shared/modules/cart/stores/useCartStore";
+import { AddToCartForm } from "@/_shared/modules/product/components/AddToCartForm";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/_shared/components/sheet";
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+
+interface AddToCartSheetProps {
+  productId: string;
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+}
+
+function AddToCartSheet({
+  productId,
+  isOpen,
+  onOpenChange,
+}: AddToCartSheetProps) {
+  const addToCart = useCartStore((s) => s.addToCart);
+  const queryClient = useQueryClient();
+
+  const { data: productDetail } = useQuery({
+    queryKey: ["productDetail", productId],
+    queryFn: () => fetchProductDetail(productId),
+  });
+
+  const handleAddToCart = async (optionId: string, quantity: number) => {
+    if (!productDetail) return;
+    try {
+      const selectedOption = productDetail.options?.find(
+        (option) => option.id === optionId
+      );
+      if (!selectedOption) return;
+      addToCart(
+        productDetail.product,
+        [selectedOption],
+        quantity,
+        productDetail.discount?.discountedPrice,
+        productDetail.options
+      );
+      onOpenChange(false);
+      await queryClient.invalidateQueries({ queryKey: ["cart"] });
+    } catch (_error: unknown) {
+      return;
+    }
+  };
+
+  return (
+    <Sheet open={isOpen} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        className="h-[85vh] max-w-[468px] mx-auto rounded-t-2xl p-0 flex flex-col"
+      >
+        <VisuallyHidden>
+          <SheetHeader className="p-4 pb-2 flex-shrink-0">
+            <SheetTitle className="text-left">
+              {productDetail?.product.name}
+            </SheetTitle>
+            <SheetDescription className="text-left">
+              원하는 옵션을 선택해주세요
+            </SheetDescription>
+          </SheetHeader>
+        </VisuallyHidden>
+
+        <div className="flex-1 overflow-hidden">
+          {productDetail && (
+            <AddToCartForm
+              productDetail={productDetail}
+              onAddToCart={handleAddToCart}
+            />
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export { AddToCartSheet };

--- a/src/_shared/modules/product/components/AddToCartSheet.tsx
+++ b/src/_shared/modules/product/components/AddToCartSheet.tsx
@@ -1,10 +1,10 @@
 "use client";
 
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { fetchProductDetail } from "@/lib/api/productApi";
 import { useCartStore } from "@/_shared/modules/cart/stores/useCartStore";
-import { AddToCartForm } from "@/_shared/modules/product/components/AddToCartForm";
+
 import {
   Sheet,
   SheetContent,
@@ -12,7 +12,9 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/_shared/components/sheet";
-import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+import { AddToCartForm } from "@/_shared/modules/product/components/AddToCartForm";
+
+import { fetchProductDetail } from "@/lib/api/productApi";
 
 interface AddToCartSheetProps {
   productId: string;

--- a/src/_shared/modules/product/components/ProductCard.tsx
+++ b/src/_shared/modules/product/components/ProductCard.tsx
@@ -1,16 +1,16 @@
 "use client";
 
+import { MouseEvent,useState } from "react";
 import Link from "next/link";
-import { useState, MouseEvent } from "react";
 
 import { ProductPreviewInfo } from "@/lib/types/productType";
 
 import { OPTION_TEXT } from "@/lib/styles";
 
-import { ProductImage } from "@/_shared/modules/product/components/ProductImage";
-import { ProductPrice } from "@/_shared/modules/product/components/ProductPrice";
 import { AddToCartButton } from "@/_shared/modules/product/components/AddToCartButton";
 import { AddToCartSheet } from "@/_shared/modules/product/components/AddToCartSheet";
+import { ProductImage } from "@/_shared/modules/product/components/ProductImage";
+import { ProductPrice } from "@/_shared/modules/product/components/ProductPrice";
 
 interface ProductCardProps {
   product: ProductPreviewInfo;

--- a/src/_shared/modules/product/components/ProductCard.tsx
+++ b/src/_shared/modules/product/components/ProductCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useState, MouseEvent } from "react";
 
 import { ProductPreviewInfo } from "@/lib/types/productType";
 
@@ -8,15 +9,31 @@ import { OPTION_TEXT } from "@/lib/styles";
 
 import { ProductImage } from "@/_shared/modules/product/components/ProductImage";
 import { ProductPrice } from "@/_shared/modules/product/components/ProductPrice";
+import { AddToCartButton } from "@/_shared/modules/product/components/AddToCartButton";
+import { AddToCartSheet } from "@/_shared/modules/product/components/AddToCartSheet";
+
 interface ProductCardProps {
   product: ProductPreviewInfo;
 }
 
 function ProductCard({ product }: ProductCardProps) {
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+
+  const handleAddToCartClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsSheetOpen(true);
+  };
+
   return (
     <li>
       <Link href={`/product/${product.id}`}>
-        <ProductImage product={product} />
+        <div className="relative">
+          <ProductImage product={product} />
+          <div className="absolute top-2 right-2 z-10">
+            <AddToCartButton onClick={handleAddToCartClick} />
+          </div>
+        </div>
         <div className="space-y-1">
           <h3 className="text-sm font-medium text-gray-900 line-clamp-2">
             {product.name}
@@ -32,6 +49,11 @@ function ProductCard({ product }: ProductCardProps) {
           </div>
         </div>
       </Link>
+      <AddToCartSheet
+        productId={product.id}
+        isOpen={isSheetOpen}
+        onOpenChange={setIsSheetOpen}
+      />
     </li>
   );
 }

--- a/src/_shared/modules/product/components/ProductImage.tsx
+++ b/src/_shared/modules/product/components/ProductImage.tsx
@@ -23,6 +23,7 @@ function ProductImage({
         fill
         sizes={containerSize}
         priority={containerSize !== "small"}
+        className="object-cover"
       />
     </div>
   );

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -38,7 +38,7 @@ const handleApiError = <T>(error: unknown, defaultValue: T): T => {
 const fetchWithErrorHandling = async <T>(
   url: string,
   errorMessage: string,
-  defaultValue: T,
+  defaultValue: T
 ): Promise<T> => {
   try {
     const response = await fetch(url);


### PR DESCRIPTION
## #️⃣연관된 이슈

- #82 

## 📝작업 내용

- 이미지 크기를 맞추기 위해 product image 컴포넌트에 object-cover style 속성 추가
- 상세 페이지에 진입하지 않고도 상품을 바로 장바구니에 추가하기 위해 AddToCartButton과 Form, Sheet 컴포넌트 추가
