### PR TITLE
fix: point timer local storage에 저장

### DIFF
--- a/src/_shared/modules/point/components/PointDisplay.tsx
+++ b/src/_shared/modules/point/components/PointDisplay.tsx
@@ -4,8 +4,8 @@ import { useEffect, useState } from "react";
 
 import { POINT_DISPLAY } from "@/lib/styles";
 
-import { usePointTimerStore } from "@/_shared/modules/point/stores/usePointTimerStore";
 import { usePointTimerSync } from "@/_shared/modules/point/hooks/usePointTimerSync";
+import { usePointTimerStore } from "@/_shared/modules/point/stores/usePointTimerStore";
 
 import {
   POINT_MESSAGE_DURATION_MS,

--- a/src/_shared/modules/point/components/PointDisplay.tsx
+++ b/src/_shared/modules/point/components/PointDisplay.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from "react";
 
 import { POINT_DISPLAY } from "@/lib/styles";
 
-import usePointTimerStore from "@/_shared/modules/point/stores/usePointTimerStore";
+import { usePointTimerStore } from "@/_shared/modules/point/stores/usePointTimerStore";
+import { usePointTimerSync } from "@/_shared/modules/point/hooks/usePointTimerSync";
 
 import {
   POINT_MESSAGE_DURATION_MS,
@@ -12,6 +13,8 @@ import {
 } from "@/lib/constants/point";
 
 function PointDisplay() {
+  usePointTimerSync();
+
   const {
     scrollTimeElapsed,
     pauseScrollTimer,

--- a/src/_shared/modules/point/hooks/usePointTimerSync.tsx
+++ b/src/_shared/modules/point/hooks/usePointTimerSync.tsx
@@ -8,12 +8,10 @@ import { usePointTimerStore } from "@/_shared/modules/point/stores/usePointTimer
  * 탭 간 포인트 타이머 상태 동기화를 위한 훅
  */
 function usePointTimerSync() {
-  const { syncStateFromStorage, initializeSession } = usePointTimerStore();
+  const { syncStateFromStorage } = usePointTimerStore();
 
   useEffect(() => {
     syncStateFromStorage();
-
-    initializeSession();
 
     const handleFocus = () => {
       syncStateFromStorage();
@@ -32,7 +30,7 @@ function usePointTimerSync() {
       window.removeEventListener("focus", handleFocus);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [syncStateFromStorage, initializeSession]);
+  }, [syncStateFromStorage]);
 }
 
 export { usePointTimerSync };

--- a/src/_shared/modules/point/hooks/usePointTimerSync.tsx
+++ b/src/_shared/modules/point/hooks/usePointTimerSync.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePointTimerStore } from "@/_shared/modules/point/stores/usePointTimerStore";
+
+/**
+ * 탭 간 포인트 타이머 상태 동기화를 위한 훅
+ */
+function usePointTimerSync() {
+  const { syncStateFromStorage, initializeSession } = usePointTimerStore();
+
+  useEffect(() => {
+    syncStateFromStorage();
+
+    initializeSession();
+
+    const handleFocus = () => {
+      syncStateFromStorage();
+    };
+
+    const handleVisibilityChange = () => {
+      if (!document.hidden) {
+        syncStateFromStorage();
+      }
+    };
+
+    window.addEventListener("focus", handleFocus);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener("focus", handleFocus);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [syncStateFromStorage, initializeSession]);
+}
+
+export { usePointTimerSync };

--- a/src/_shared/modules/point/hooks/usePointTimerSync.tsx
+++ b/src/_shared/modules/point/hooks/usePointTimerSync.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+
 import { usePointTimerStore } from "@/_shared/modules/point/stores/usePointTimerStore";
 
 /**

--- a/src/_shared/modules/point/hooks/useScrollActivity.tsx
+++ b/src/_shared/modules/point/hooks/useScrollActivity.tsx
@@ -1,13 +1,13 @@
 import { RefObject, useCallback, useEffect, useMemo, useRef } from "react";
 import { throttle } from "lodash";
 
-import usePointTimerStore from "@/_shared/modules/point/stores/usePointTimerStore";
+import { usePointTimerStore } from "@/_shared/modules/point/stores/usePointTimerStore";
+import { usePointTimerSync } from "@/_shared/modules/point/hooks/usePointTimerSync";
 
 import {
   MIN_SCROLL_DELTA,
   POINTS_PER_INTERVAL,
   SCROLL_INACTIVITY_THRESHOLD_MS,
-  SCROLL_POINT_GAIN_INTERVAL_MS,
   SCROLL_THROTTLE_INTERVAL_MS,
   TOTAL_SCROLL_TIME_FOR_POINTS_MS,
 } from "@/lib/constants/point";
@@ -21,10 +21,12 @@ interface UseScrollActivityProps {
  * @param mainRef - 스크롤 메인 요소 참조
  */
 function useScrollActivity({ mainRef }: UseScrollActivityProps) {
+  usePointTimerSync();
+
   const {
     isScrolling,
     scrollTimeElapsed,
-    incrementScrollTime,
+    updateScrollTime,
     resetScrollTimer,
     addPoints,
     startScrollTimer,
@@ -89,11 +91,11 @@ function useScrollActivity({ mainRef }: UseScrollActivityProps) {
     if (!isScrolling) return;
 
     const intervalId = window.setInterval(() => {
-      incrementScrollTime(SCROLL_POINT_GAIN_INTERVAL_MS);
-    }, SCROLL_POINT_GAIN_INTERVAL_MS);
+      updateScrollTime();
+    }, 100);
 
     return () => clearInterval(intervalId);
-  }, [isScrolling, incrementScrollTime]);
+  }, [isScrolling, updateScrollTime]);
 
   /**
    * 포인트 지급

--- a/src/_shared/modules/point/hooks/useScrollActivity.tsx
+++ b/src/_shared/modules/point/hooks/useScrollActivity.tsx
@@ -92,7 +92,7 @@ function useScrollActivity({ mainRef }: UseScrollActivityProps) {
 
     const intervalId = window.setInterval(() => {
       updateScrollTime();
-    }, 100);
+    }, SCROLL_THROTTLE_INTERVAL_MS);
 
     return () => clearInterval(intervalId);
   }, [isScrolling, updateScrollTime]);

--- a/src/_shared/modules/point/hooks/useScrollActivity.tsx
+++ b/src/_shared/modules/point/hooks/useScrollActivity.tsx
@@ -1,8 +1,8 @@
 import { RefObject, useCallback, useEffect, useMemo, useRef } from "react";
 import { throttle } from "lodash";
 
-import { usePointTimerStore } from "@/_shared/modules/point/stores/usePointTimerStore";
 import { usePointTimerSync } from "@/_shared/modules/point/hooks/usePointTimerSync";
+import { usePointTimerStore } from "@/_shared/modules/point/stores/usePointTimerStore";
 
 import {
   MIN_SCROLL_DELTA,

--- a/src/_shared/modules/point/stores/usePointTimerStore.tsx
+++ b/src/_shared/modules/point/stores/usePointTimerStore.tsx
@@ -1,54 +1,220 @@
 import { create } from "zustand";
+import { persist, subscribeWithSelector } from "zustand/middleware";
 
-type PointTimerState = {
+type PointTimerState = {  
   scrollTimeElapsed: number;
   isScrolling: boolean;
   points: number;
   lastScrollActivity: number;
   lastPointsAdded: number;
+  sessionStartTime: number;
+  scrollStartTime: number | null;
+  accumulatedScrollTime: number;
 };
 
 type PointTimerActions = {
   startScrollTimer: () => void;
   pauseScrollTimer: () => void;
-  incrementScrollTime: (time: number) => void;
+  updateScrollTime: () => void;
   resetScrollTimer: () => void;
   addPoints: (amount: number) => void;
   clearLastPointsAdded: () => void;
+  initializeSession: () => void;
+  syncStateFromStorage: () => void;
+};
+
+const POINT_TIMER_STORAGE_KEY = "point-timer-store";
+const POINT_TIMER_CHANNEL = "point-timer-sync";
+let broadcastChannel: BroadcastChannel | null = null;
+
+if (typeof window !== "undefined") {
+  broadcastChannel = new BroadcastChannel(POINT_TIMER_CHANNEL);
 }
 
-const usePointTimerStore = create<PointTimerState & PointTimerActions>(
-  (set, _get) => ({
-    scrollTimeElapsed: 0,
-    isScrolling: false,
-    points: 0,
-    lastScrollActivity: 0,
-    lastPointsAdded: 0,
+const usePointTimerStore = create<PointTimerState & PointTimerActions>()(
+  subscribeWithSelector(
+    persist(
+      (set, _get) => ({
+        scrollTimeElapsed: 0,
+        isScrolling: false,
+        points: 0,
+        lastScrollActivity: 0,
+        lastPointsAdded: 0,
+        sessionStartTime: Date.now(),
+        scrollStartTime: null,
+        accumulatedScrollTime: 0,
 
-    startScrollTimer: () => {
-      set({ isScrolling: true, lastScrollActivity: Date.now() });
-    },
-    pauseScrollTimer: () => {
-      set({ isScrolling: false });
-    },
-    incrementScrollTime: (time: number) => {
-      set((state) => ({
-        scrollTimeElapsed: state.scrollTimeElapsed + time,
-      }));
-    },
-    resetScrollTimer: () => {
-      set({ scrollTimeElapsed: 0, lastScrollActivity: Date.now() });
-    },
-    addPoints: (amount: number) => {
-      set((state) => ({
-        points: state.points + amount,
-        lastPointsAdded: amount,
-      }));
-    },
-    clearLastPointsAdded: () => {
-      set({ lastPointsAdded: 0 });
-    },
-  })
+        initializeSession: () => {
+          const currentTime = Date.now();
+          set({ sessionStartTime: currentTime });
+        },
+
+        syncStateFromStorage: () => {
+          // localStorage에서 최신 상태를 가져와서 동기화
+          const storedState = localStorage.getItem(POINT_TIMER_STORAGE_KEY);
+          if (storedState) {
+            try {
+              const parsedState = JSON.parse(storedState);
+              if (parsedState?.state) {
+                set(parsedState.state);
+              }
+            } catch (error) {
+              console.error("Failed to sync state from storage:", error);
+            }
+          }
+        },
+
+        startScrollTimer: () => {
+          set((state) => {
+            const currentTime = Date.now();
+            const newState = {
+              isScrolling: true,
+              lastScrollActivity: currentTime,
+              scrollStartTime: state.scrollStartTime || currentTime, // 처음 시작할 때만 설정
+            };
+
+            // 다른 탭에 상태 변경 알림
+            if (broadcastChannel) {
+              broadcastChannel.postMessage({
+                type: "STATE_UPDATE",
+                payload: newState,
+              });
+            }
+
+            return newState;
+          });
+        },
+
+        pauseScrollTimer: () => {
+          set((state) => {
+            const currentTime = Date.now();
+            let newAccumulatedTime = state.accumulatedScrollTime;
+
+            // 스크롤 중이었다면 현재까지의 시간을 누적에 추가
+            if (state.isScrolling && state.scrollStartTime) {
+              const sessionTime = currentTime - state.scrollStartTime;
+              newAccumulatedTime = state.accumulatedScrollTime + sessionTime;
+            }
+
+            const newState = {
+              isScrolling: false,
+              scrollStartTime: null,
+              accumulatedScrollTime: newAccumulatedTime,
+            };
+
+            if (broadcastChannel) {
+              broadcastChannel.postMessage({
+                type: "STATE_UPDATE",
+                payload: newState,
+              });
+            }
+
+            return newState;
+          });
+        },
+
+        updateScrollTime: () => {
+          set((state) => {
+            if (!state.isScrolling || !state.scrollStartTime) {
+              return state;
+            }
+
+            const currentTime = Date.now();
+            const currentSessionTime = currentTime - state.scrollStartTime;
+            const totalElapsed =
+              state.accumulatedScrollTime + currentSessionTime;
+
+            const newState = {
+              scrollTimeElapsed: totalElapsed,
+            };
+
+            if (broadcastChannel) {
+              broadcastChannel.postMessage({
+                type: "STATE_UPDATE",
+                payload: newState,
+              });
+            }
+
+            return newState;
+          });
+        },
+
+        resetScrollTimer: () => {
+          const newState = {
+            scrollTimeElapsed: 0,
+            accumulatedScrollTime: 0,
+            scrollStartTime: null,
+            lastScrollActivity: Date.now(),
+          };
+          set(newState);
+
+          if (broadcastChannel) {
+            broadcastChannel.postMessage({
+              type: "STATE_UPDATE",
+              payload: newState,
+            });
+          }
+        },
+
+        addPoints: (amount: number) => {
+          set((state) => {
+            const newState = {
+              points: state.points + amount,
+              lastPointsAdded: amount,
+            };
+
+            if (broadcastChannel) {
+              broadcastChannel.postMessage({
+                type: "STATE_UPDATE",
+                payload: newState,
+              });
+            }
+
+            return newState;
+          });
+        },
+
+        clearLastPointsAdded: () => {
+          const newState = { lastPointsAdded: 0 };
+          set(newState);
+
+          if (broadcastChannel) {
+            broadcastChannel.postMessage({
+              type: "STATE_UPDATE",
+              payload: newState,
+            });
+          }
+        },
+      }),
+      {
+        name: POINT_TIMER_STORAGE_KEY,
+        storage: {
+          getItem: (name) => {
+            const str = localStorage.getItem(name);
+            if (!str) return null;
+            return JSON.parse(str);
+          },
+          setItem: (name, value) => {
+            localStorage.setItem(name, JSON.stringify(value));
+          },
+          removeItem: (name) => localStorage.removeItem(name),
+        },
+      }
+    )
+  )
 );
 
-export default usePointTimerStore;
+if (broadcastChannel) {
+  broadcastChannel.addEventListener("message", (event) => {
+    const { type, payload } = event.data;
+
+    if (type === "STATE_UPDATE" && payload) {
+      usePointTimerStore.setState((state) => ({
+        ...state,
+        ...payload,
+      }));
+    }
+  });
+}
+
+export { usePointTimerStore };

--- a/src/_shared/modules/point/stores/usePointTimerStore.tsx
+++ b/src/_shared/modules/point/stores/usePointTimerStore.tsx
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { persist, subscribeWithSelector } from "zustand/middleware";
 
-type PointTimerState = {  
+type PointTimerState = {
   scrollTimeElapsed: number;
   isScrolling: boolean;
   points: number;
@@ -19,7 +19,6 @@ type PointTimerActions = {
   resetScrollTimer: () => void;
   addPoints: (amount: number) => void;
   clearLastPointsAdded: () => void;
-  initializeSession: () => void;
   syncStateFromStorage: () => void;
 };
 
@@ -43,11 +42,6 @@ const usePointTimerStore = create<PointTimerState & PointTimerActions>()(
         sessionStartTime: Date.now(),
         scrollStartTime: null,
         accumulatedScrollTime: 0,
-
-        initializeSession: () => {
-          const currentTime = Date.now();
-          set({ sessionStartTime: currentTime });
-        },
 
         syncStateFromStorage: () => {
           // localStorage에서 최신 상태를 가져와서 동기화


### PR DESCRIPTION
## #️⃣연관된 이슈

- #95 

## 📝작업 내용
### AS-IS
- point timer 상태를 따로 storage에 저장하지 않아서 타이머가 탭별로 개별 동작하는 문제점 발생
### TO-BE
- 전체 탭에서 동일한 상태를 공유하기 위해 local storage에 타이머 상태를 저장하고 broadcast channel api를 활용해 스크롤 이벤트를 동기화
- 탭이 focus되거나 visible할 때만 최신 상태를 동기화 하기 위해 `_shared/modules/point/hooks`에 usePointTimerSync hook 추가
